### PR TITLE
Set frustum scale for metashape meshes

### DIFF
--- a/multiview_mapping_toolkit/cameras/cameras.py
+++ b/multiview_mapping_toolkit/cameras/cameras.py
@@ -3,7 +3,6 @@ import shutil
 from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List, Tuple, Union
-from scipy.spatial.distance import pdist
 
 import geopandas as gpd
 import numpy as np
@@ -13,6 +12,7 @@ import pyvista as pv
 import torch
 from pytorch3d.renderer import PerspectiveCameras
 from pyvista import demos
+from scipy.spatial.distance import pdist
 from shapely import Point
 from skimage.io import imread
 from skimage.transform import resize

--- a/multiview_mapping_toolkit/meshes/meshes.py
+++ b/multiview_mapping_toolkit/meshes/meshes.py
@@ -1760,6 +1760,7 @@ class TexturedPhotogrammetryMesh:
             mesh_kwargs: dict of keyword arguments for the mesh
             interactive_jupyter (bool): should jupyter windows be interactive. This doesn't always work, especially on VSCode.
             plotter_kwargs: dict of keyword arguments for the plotter
+            frustum_scale (float): Scaling factor for visualizing camera frustums. Defaults to 0.1
         """
         off_screen = (not interactive) or (screenshot_filename is not None)
         if off_screen or force_xvfb:
@@ -1825,6 +1826,7 @@ class TexturedPhotogrammetryMesh:
         # If the camera set is provided, show this too
         if camera_set is not None:
             # Adjust the frustum scale if the mesh came from metashape
+            # Find the cube root of the determinant of the upper-left 3x3 submatrix to find the scaling factor 
             if self.local_to_epgs_4978_transform is not None:
                 transform_determinant = np.linalg.det(self.local_to_epgs_4978_transform[:3, :3])
                 scale_factor = np.cbrt(transform_determinant)

--- a/multiview_mapping_toolkit/meshes/meshes.py
+++ b/multiview_mapping_toolkit/meshes/meshes.py
@@ -1824,6 +1824,11 @@ class TexturedPhotogrammetryMesh:
         )
         # If the camera set is provided, show this too
         if camera_set is not None:
+            # Adjust the frustum scale if the mesh came from metashape
+            if self.local_to_epgs_4978_transform is not None:
+                transform_determinant = np.linalg.det(self.local_to_epgs_4978_transform[:3, :3])
+                scale_factor = np.cbrt(transform_determinant)
+                frustum_scale = frustum_scale / scale_factor
             camera_set.vis(
                 plotter, add_orientation_cube=False, frustum_scale=frustum_scale
             )

--- a/multiview_mapping_toolkit/meshes/meshes.py
+++ b/multiview_mapping_toolkit/meshes/meshes.py
@@ -1747,7 +1747,7 @@ class TexturedPhotogrammetryMesh:
         plotter_kwargs: typing.Dict = {},
         enable_ssao: bool = True,
         force_xvfb: bool = False,
-        frustum_scale: float = 0.1,
+        frustum_scale: float = None,
     ):
         """Show the mesh and cameras
 
@@ -1760,7 +1760,7 @@ class TexturedPhotogrammetryMesh:
             mesh_kwargs: dict of keyword arguments for the mesh
             interactive_jupyter (bool): should jupyter windows be interactive. This doesn't always work, especially on VSCode.
             plotter_kwargs: dict of keyword arguments for the plotter
-            frustum_scale (float): Scaling factor for visualizing camera frustums. Defaults to 0.1
+            frustum_scale (float, optional): Size of cameras in world units
         """
         off_screen = (not interactive) or (screenshot_filename is not None)
         if off_screen or force_xvfb:
@@ -1827,7 +1827,7 @@ class TexturedPhotogrammetryMesh:
         if camera_set is not None:
             # Adjust the frustum scale if the mesh came from metashape
             # Find the cube root of the determinant of the upper-left 3x3 submatrix to find the scaling factor 
-            if self.local_to_epgs_4978_transform is not None:
+            if self.local_to_epgs_4978_transform is not None and frustum_scale is not None:
                 transform_determinant = np.linalg.det(self.local_to_epgs_4978_transform[:3, :3])
                 scale_factor = np.cbrt(transform_determinant)
                 frustum_scale = frustum_scale / scale_factor


### PR DESCRIPTION
This enables the user to specify the `frustum_scale` in the jupyter notebooks. The size of the frustums shown in the mesh can be modified by changing the `frustum_scale` parameter.