### PR TITLE
Accelerate labeling polygons from per-face labels

### DIFF
--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -971,7 +971,7 @@ class TexturedPhotogrammetryMesh:
                 Whether to use `gpd.sjoin` or `gpd.overlay` to compute the overlay. Sjoin is
                 substaintially faster, but only uses mesh faces that are entirely within the bounds
                 of the polygon, rather than computing the intersecting region for
-                partially-overlapping faces.
+                partially-overlapping faces. Defaults to True.
             return_class_labels: (bool, optional):
                 Return string representation of class labels rather than float. Defaults to True.
             unknown_class_label (str, optional):

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -1080,10 +1080,9 @@ class TexturedPhotogrammetryMesh:
         # Compute the weighted area for each face, which may have been broken up by the overlay
         overlay["weighted_area"] = overlay.area * overlay["face_weighting"]
 
-        weighted_area_df = overlay.loc[:, ["polygon_ID", CLASS_ID_KEY, "weighted_area"]]
-        aggregated_data = weighted_area_df.groupby(["polygon_ID", CLASS_ID_KEY]).agg(
-            np.sum
-        )
+        # Extract only the neccessary columns
+        overlay = overlay.loc[:, ["polygon_ID", CLASS_ID_KEY, "weighted_area"]]
+        aggregated_data = overlay.groupby(["polygon_ID", CLASS_ID_KEY]).agg(np.sum)
         # Compute the highest weighted class prediction
         # Modified from https://stackoverflow.com/questions/27914360/python-pandas-idxmax-for-multiple-indexes-in-a-dataframe
         max_rows = aggregated_data.loc[


### PR DESCRIPTION
The main improvement is first removing faces that are not contained by the target polygons, since this is a much faster operation than doing the overlay. This could yield slightly different results, since partially-overlapping faces are discarded. Therefore the heuristic of buffering the input polygon regions before selecting the subset of faces is used. 