### PR TITLE
Allow Caching for pix2face

### DIFF
--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -72,6 +72,14 @@ class PhotogrammetryCamera:
         )
 
     def get_camera_hash(self, include_image_hash=False):
+        """Generates a hash value for the camera's geometry and optionally includes the image
+
+        Args:
+            include_image_hash (bool, optional): Whether to include the image filename in the hash computation. Defaults to false.
+
+        Returns:
+            int: A hash value representing the current state of the camera
+        """
         # Geometric information of hash
         transform_hash = self.cam_to_world_transform.tolist()
         camera_settings = {

--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import shutil
@@ -6,7 +7,6 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
 import geopandas as gpd
-import json
 import numpy as np
 import numpy.ma as ma
 import pyproj

--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, List, Tuple, Union
 
 import geopandas as gpd
+import json
 import numpy as np
 import numpy.ma as ma
 import pyproj
@@ -69,6 +70,20 @@ class PhotogrammetryCamera:
         self.cache_image = (
             False  # Only set to true if you can hold all images in memory
         )
+
+    def get_camera_hash(self):
+        transform_hash = self.cam_to_world_transform.tolist()
+        camera_settings = json.dumps({
+            'transform': transform_hash,
+            'f': self.f,
+            'cx': self.cx,
+            'cy': self.cy,
+            'image_width': self.image_width,
+            'image_height': self.image_height,
+            'distortion_params': self.distortion_params,
+            'lon_lat': self.lon_lat
+        }, sort_keys=True)
+        return hash(camera_settings)
 
     def get_image(self, image_scale: float = 1.0) -> np.ndarray:
         # Check if the image is cached
@@ -560,6 +575,17 @@ class PhotogrammetryCameraSet:
                 image_filename, cam_to_world_transform, lon_lat=lon_lat, **sensor_params
             )
             self.cameras.append(new_camera)
+
+    def get_camera_hash(self):
+        transform_hash = self.cam_to_world_transform.tolist()
+        camera_settings = json.dumps({
+            'transform': transform_hash,
+            'intrinsic_params_per_sensor_type': self.intrinsic_params_per_sensor_type,
+            'lon_lats': self.lon_lats,
+            'sensor_IDs': self.sensor_IDs,
+            'validate_images': self.validate_images
+        }, sort_keys=True)
+        return hash(camera_settings)
 
     def __len__(self):
         return self.n_cameras()

--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -96,7 +96,7 @@ class PhotogrammetryCamera:
         # Include the image associated with the hash if specified
         if include_image_hash:
             camera_settings['image_filename'] = str(self.image_filename)
-        
+
         camera_settings_data = json.dumps(camera_settings, sort_keys=True)
 
         return hash(camera_settings_data)

--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -71,7 +71,7 @@ class PhotogrammetryCamera:
             False  # Only set to true if you can hold all images in memory
         )
 
-    def get_camera_hash(self, include_image_hash=False):
+    def get_camera_hash(self, include_image_hash: bool = False):
         """Generates a hash value for the camera's geometry and optionally includes the image
 
         Args:

--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -576,17 +576,6 @@ class PhotogrammetryCameraSet:
             )
             self.cameras.append(new_camera)
 
-    def get_camera_hash(self):
-        transform_hash = self.cam_to_world_transform.tolist()
-        camera_settings = json.dumps({
-            'transform': transform_hash,
-            'intrinsic_params_per_sensor_type': self.intrinsic_params_per_sensor_type,
-            'lon_lats': self.lon_lats,
-            'sensor_IDs': self.sensor_IDs,
-            'validate_images': self.validate_images
-        }, sort_keys=True)
-        return hash(camera_settings)
-
     def __len__(self):
         return self.n_cameras()
 

--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -71,9 +71,10 @@ class PhotogrammetryCamera:
             False  # Only set to true if you can hold all images in memory
         )
 
-    def get_camera_hash(self):
+    def get_camera_hash(self, include_image_hash=False):
+        # Geometric information of hash
         transform_hash = self.cam_to_world_transform.tolist()
-        camera_settings = json.dumps({
+        camera_settings = {
             'transform': transform_hash,
             'f': self.f,
             'cx': self.cx,
@@ -82,8 +83,15 @@ class PhotogrammetryCamera:
             'image_height': self.image_height,
             'distortion_params': self.distortion_params,
             'lon_lat': self.lon_lat
-        }, sort_keys=True)
-        return hash(camera_settings)
+        }
+
+        # Include the image associated with the hash if specified
+        if include_image_hash:
+            camera_settings['image_filename'] = str(self.image_filename)
+        
+        camera_settings_data = json.dumps(camera_settings, sort_keys=True)
+
+        return hash(camera_settings_data)
 
     def get_image(self, image_scale: float = 1.0) -> np.ndarray:
         # Check if the image is cached

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -1295,9 +1295,8 @@ class TexturedPhotogrammetryMesh:
         self      
     ):
         points = self.pyvista_mesh.points.tobytes()
-        edges = self.pyvista_mesh.extract_edges().points.tobytes()
         faces = self.pyvista_mesh.faces.tobytes()
-        return hash(points + edges + faces)
+        return hash(points + faces)
 
     def pix2face(
         self,
@@ -1332,10 +1331,12 @@ class TexturedPhotogrammetryMesh:
             pix2face_list = []
             # each camera has its own pix2face correspondance with a mesh 
             for camera in cameras:
-                mesh_hash = self.get_mesh_hash() 
-                camera_hash = camera.get_camera_hash()
-                cacher = ub.Cacher('pix2face', depends=[mesh_hash, camera_hash, render_img_scale])
-                pix2face = cacher.tryload(on_error='clear')
+
+                # mesh_hash = self.get_mesh_hash() 
+                # camera_hash = camera.get_camera_hash()
+                # cacher = ub.Cacher('pix2face', depends=[mesh_hash, camera_hash, render_img_scale])
+                # pix2face = cacher.tryload(on_error='clear')
+                
                 if pix2face is None: # pix2face = None, means cache expired
                     result = self.pix2face(camera, render_img_scale=render_img_scale)
                     pix2face_list.append(result)            

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -1290,9 +1290,9 @@ class TexturedPhotogrammetryMesh:
             self.set_texture(labels, use_derived_IDs_to_labels=False)
 
         return labels
-    
+
     def get_mesh_hash(
-        self      
+        self
     ):
         """Generates a hash value for the mesh based on its points and faces
 
@@ -1333,10 +1333,10 @@ class TexturedPhotogrammetryMesh:
             pix2face_list = [
                 self.pix2face(camera, render_img_scale=render_img_scale)
                 for camera in cameras
-            ]on_error
+            ]
             pix2face = np.stack(pix2face_list, axis=0)
             return pix2face
-        
+
         ## Single camera case
 
         # Check if the cache contains a valid pix2face for the camera based on the dependencies
@@ -1349,7 +1349,7 @@ class TexturedPhotogrammetryMesh:
         camera_hash = cameras.get_camera_hash()
         cacher = ub.Cacher('pix2face', depends=[mesh_hash, camera_hash, render_img_scale])
         pix2face = cacher.tryload(on_error='clear')
-        # Cache is valid 
+        # Cache is valid
         if pix2face is not None:
             return pix2face
 

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -15,10 +15,10 @@ import pyvista as pv
 import rasterio as rio
 import shapely
 import skimage
-from shapely import MultiPolygon, Polygon
-from skimage.transform import resize # might look into for cache
-from tqdm import tqdm
 import ubelt as ub
+from shapely import MultiPolygon, Polygon
+from skimage.transform import resize  # might look into for cache
+from tqdm import tqdm
 
 from geograypher.cameras import PhotogrammetryCamera, PhotogrammetryCameraSet
 from geograypher.constants import (

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -18,6 +18,7 @@ import skimage
 from shapely import MultiPolygon, Polygon
 from skimage.transform import resize
 from tqdm import tqdm
+import ubelt as ub
 
 from geograypher.cameras import PhotogrammetryCamera, PhotogrammetryCameraSet
 from geograypher.constants import (
@@ -1316,6 +1317,17 @@ class TexturedPhotogrammetryMesh:
         # If a set of cameras is passed in, call this method on each camera and concatenate
         # Other derived methods might be able to compute a batch of renders and once, but pyvista
         # cannot as far as I can tell
+
+        mesh_hash = hash(self.pyvista_mesh.points.tobytes())
+        camera_hash = hash(self.cameras.get_camera_hash())
+
+        cacher = ub.Cacher('pix2face', depends=[mesh_hash, camera_hash])
+
+        pix2face = cacher.tryload(on_error='clear')
+
+        if pix2face is not None:
+            return pix2face
+
         if isinstance(cameras, PhotogrammetryCameraSet):
             pix2face_list = [
                 self.pix2face(camera, render_img_scale=render_img_scale)
@@ -1387,6 +1399,8 @@ class TexturedPhotogrammetryMesh:
         # erronously masked. This seems like a minimal concern but it could be addressed by adding
         # another channel or something like that
         pix2face[pix2face > n_faces] = -1
+
+        cacher.save(pix2face)
 
         return pix2face
 


### PR DESCRIPTION
This pull request introduces disk-based caching for the `pix2face` computation. 

`cacher = ub.Cacher('pix2face', depends=[mesh_hash, camera_hash, render_img_scale])`

`ub.Cacher` provides on-disk caching so that the cache files persist across multiple Python instances. 

The cache generates unique keys for each combination of the dependencies (`mesh_hash`, `camera_hash`, `render_img_scale`). For each unique key generated the cache will create a cache file on disk. So if we have multiple combinations of `mesh_hash`, `camera_hash`, `render_img_scale`, there will be a specific cache file on disk for each combination. 

`pix2face = cacher.tryload(on_error='clear')`

`tryload` tries to load the cached data. If there’s an error loading, like data corruption, then the cache will clear its contents, signified by `on_error='clear'`. 

To test if the cache files last between Python instances, I ran the `concept_figures` code and ran it again without restarting the kernel. The second time around there were no cache misses and all cache hits. 