### PR TITLE
Trigger black workflow with `workflow_run`

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,5 +1,6 @@
 name: Black Linter
 
+# This allows Black be called from the isort workflow
 on:
   workflow_call:
 
@@ -36,4 +37,4 @@ jobs:
       - name: Push changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Apply formatting changes
+          commit_message: Apply black formatting changes

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,16 +1,13 @@
 name: Black Linter
 
 on:
-  workflow_run:
-    workflows: [Isort Linter]
-    types:
-      - completed
+  workflow_call:
 
 jobs:
   black-linter:
     name: Run Black
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Determine Branch Name
         run: |

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -1,4 +1,4 @@
-name: ISort Linter
+name: Code Formatter
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   isort:
-    name: Run Isort 
+    name: Run Isort
     runs-on: ubuntu-latest
 
     steps:
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-          
+
       - name: Run Isort
         run: pip install isort==5.13.2 && isort .
 
@@ -38,4 +38,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Apply formatting changes
-      
+
+  black:
+    needs: isort
+    uses: ./.github/workflows/black.yml

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Push changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: Apply formatting changes
+          commit_message: Apply isort formatting changes
 
+  # Ensure Black runs after Isort has completed
   black:
     needs: isort
     uses: ./.github/workflows/black.yml

--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -810,7 +810,7 @@ class PhotogrammetryCameraSet:
                 List of cameras that fall within the provided ROI
         """
         # construct GeoDataFrame if not provided
-        if isinstance(ROI, (Polygon,MultiPolygon)):
+        if isinstance(ROI, (Polygon, MultiPolygon)):
             # assume geodata is lat/lon if is_geospatial is True
             if is_geospatial:
                 ROI = gpd.GeoDataFrame(crs=LAT_LON_EPSG_CODE, geometry=[ROI])
@@ -1116,21 +1116,3 @@ class PhotogrammetryCameraSet:
             if force_xvfb:
                 safe_start_xvfb()
             plotter.show(jupyter_backend="trame" if interactive_jupyter else "static")
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -10,21 +10,15 @@ from typing import Dict, List, Tuple, Union
 import geopandas as gpd
 import networkx
 import numpy as np
-
+import numpy.ma as ma
 import pyproj
 import pyvista as pv
-from skimage.transform import resize
-from tqdm import tqdm
-
-
-import numpy.ma as ma
-
-
-
 from pyvista import demos
 from scipy.spatial.distance import pdist
 from shapely import MultiPolygon, Point, Polygon
 from skimage.io import imread
+from skimage.transform import resize
+from tqdm import tqdm
 
 from geograypher.constants import (
     DEFAULT_FRUSTUM_SCALE,

--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -10,15 +10,21 @@ from typing import Dict, List, Tuple, Union
 import geopandas as gpd
 import networkx
 import numpy as np
-import numpy.ma as ma
+
 import pyproj
 import pyvista as pv
+from skimage.transform import resize
+from tqdm import tqdm
+
+
+import numpy.ma as ma
+
+
+
 from pyvista import demos
 from scipy.spatial.distance import pdist
 from shapely import MultiPolygon, Point, Polygon
 from skimage.io import imread
-from skimage.transform import resize
-from tqdm import tqdm
 
 from geograypher.constants import (
     DEFAULT_FRUSTUM_SCALE,
@@ -810,7 +816,7 @@ class PhotogrammetryCameraSet:
                 List of cameras that fall within the provided ROI
         """
         # construct GeoDataFrame if not provided
-        if isinstance(ROI, (Polygon, MultiPolygon)):
+        if isinstance(ROI, (Polygon,MultiPolygon)):
             # assume geodata is lat/lon if is_geospatial is True
             if is_geospatial:
                 ROI = gpd.GeoDataFrame(crs=LAT_LON_EPSG_CODE, geometry=[ROI])
@@ -1116,3 +1122,21 @@ class PhotogrammetryCameraSet:
             if force_xvfb:
                 safe_start_xvfb()
             plotter.show(jupyter_backend="trame" if interactive_jupyter else "static")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
The initial setup for the isort and black workflows was that isort would first run to completion and as soon as black detected that isort has finished execution black would begin to execute. This behavior was achieved using `workflow_run`, however, it resulted in unintended behavior on pull requests since `workflow_run` changes the state of `GITHUB_REF` to the default branch, which is main. So black was only running on the main branch regardless if it was triggered by a pull request.

Now, I am using workflow_call, which indicates that a workflow can be called by another workflow. This mechanism sets `GITHUB_REF` to the same value as it was in the caller workflow. So now isort runs first and triggers black to run and black  runs on the active pull request branch since `GITHUB_REF` is the same as it was in the caller workflow. 

Also I have modified cameras.py so that both isort and black should make formatting changes in the open pull request to ensure this behavior happens. 