### PR TITLE
Add auto generated docstring documentation

### DIFF
--- a/docs/cameras/cameras.md
+++ b/docs/cameras/cameras.md
@@ -1,0 +1,7 @@
+---
+title: "Cameras Docstrings"
+---
+
+::: geograypher.cameras.PhotogrammetryCamera
+
+::: geograypher.cameras.PhotogrammetryCameraSet

--- a/docs/cameras/derived_cameras.md
+++ b/docs/cameras/derived_cameras.md
@@ -1,0 +1,7 @@
+---
+title: "Derived Cameras Docstrings"
+---
+
+::: geograypher.cameras.derived_cameras.MetashapeCameraSet
+
+::: geograypher.cameras.derived_cameras.COLMAPCameraSet

--- a/docs/cameras/index.md
+++ b/docs/cameras/index.md
@@ -1,0 +1,11 @@
+---
+weight: 10
+---
+
+# Cameras
+
+- [Cameras Docstrings](cameras.md)
+
+- [Derived Cameras Docstrings](derived_cameras.md)
+
+- [Segmentor Docstrings](segmentor.md)

--- a/docs/cameras/segmentor.md
+++ b/docs/cameras/segmentor.md
@@ -1,0 +1,5 @@
+---
+title: "Segmentor Docstrings"
+---
+
+::: geograypher.cameras.SegmentorPhotogrammetryCameraSet

--- a/docs/meshes/derived_meshes.md
+++ b/docs/meshes/derived_meshes.md
@@ -1,0 +1,5 @@
+---
+title: "Derived Mesh Docstrings"
+---
+
+::: geograypher.meshes.derived_meshes.TexturedPhotogrammetryMeshChunked

--- a/docs/meshes/index.md
+++ b/docs/meshes/index.md
@@ -1,0 +1,9 @@
+---
+weight: 10
+---
+
+# Meshes
+
+- [Derived Meshes Docstrings](derived_meshes.md)
+
+- [Meshes Docstrings](meshes.md)

--- a/docs/meshes/meshes.md
+++ b/docs/meshes/meshes.md
@@ -1,0 +1,5 @@
+---
+title: "Mesh Docstrings"
+---
+
+::: geograypher.meshes.TexturedPhotogrammetryMesh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,20 @@ plugins:
   - git-committers:
       repository: open-forest-observatory/ofo-docs
       branch: main
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          selection:
+            members_order: 'source' 
+          options:
+            heading_level: 2
+            show_root_heading: true
+            show_root_full_path: false
+            show_category_heading: true
+            show_root_toc_entry: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true            
 
 nav:
   - "← OFO home": https://openforestobservatory.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,8 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.isort]
 profile = "black"
+
+[project]
+dependencies = [
+    "mkdocstrings[python]>=0.18",
+]


### PR DESCRIPTION
I added the docstrings for all the mesh and camera files. I saw there were other files that have docstrings also but I wanted to get your feedback on the current layout before I added the rest of the docstrings. Let me know what you think about the current structure. And where to add the documentation for some of the less prominent functions with docstrings. 

In addition, I customized the UI slightly but there are more options we can configure and if we want more granular control over the UI, we can add our own CSS styling. 

If you want to run the site locally you may get an error about mkdocstrings, if so run `pip install ‘mkdocstrings[python]’` to specify we are generating docstrings for python. I'm also currently working on documenting all these commands. Otherwise, here are some screenshots that display the basic structure. 

<img width="1440" alt="Screenshot 2024-07-03 at 12 54 46 PM" src="https://github.com/open-forest-observatory/geograypher/assets/85960421/834d8b6d-2de2-4e34-8fa2-0af1609ea712">
<img width="1440" alt="Screenshot 2024-07-03 at 12 54 59 PM" src="https://github.com/open-forest-observatory/geograypher/assets/85960421/ee62875d-d52e-408c-b1a0-fbfa0abaae80">
<img width="1440" alt="Screenshot 2024-07-03 at 12 55 14 PM" src="https://github.com/open-forest-observatory/geograypher/assets/85960421/660f6911-09b3-4550-932d-f94c05c6ca82">

