### PR TITLE
Add pip install command for mkdocstrings

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,7 +27,8 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material 
+      - run: pip install mkdocs-material
+      - run: pip install "mkdocstrings[python]"
       - run: pip install mkdocs-awesome-pages-plugin
       - run: pip install mkdocs-nav-weight
       - run: pip install mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
The deployment is failing [here](https://github.com/open-forest-observatory/geograypher/actions/runs/9784645594/job/27015978786#step:12:16). It looks like the `mkdocstrings` plugin wasn't installed properly so this was my attempt to fix it. It works locally on Windows.  