### PR TITLE
Add Zenodo badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Geograypher: Multiview Semantic Reasoning with Geospatial Data
+[![DOI](https://zenodo.org/badge/644076369.svg)](https://zenodo.org/doi/10.5281/zenodo.11193026)
 
 This tool is designed for multiview image datasets where multiple photos are taken of the same scene. The goal is to address two related tasks: generating a prediction about one point in the real world using observations of that point from multiple viewpoints and locating where a point in the real world is observed in each image. The intended application is drone surveys for ecology but the tool is designed to be generalizable.
 


### PR DESCRIPTION
We have a digital object identifier (DOI) for this project through Zenodo. This change adds the badge for it on the main page of the README. I found it a bit challenging to figure out how to do it. It is buried in the github settings [page](https://zenodo.org/account/settings/github/) on zenodo. 