### PR TITLE
Export information associated with per-image detections to geospatial projections

### DIFF
--- a/geograypher/entrypoints/project_detections.py
+++ b/geograypher/entrypoints/project_detections.py
@@ -175,9 +175,9 @@ def project_detections(
             right_on="instance_ID",
             suffixes=(None, "_right"),
         )
-        # Drop the columns that are just an integer ID
+        # Drop the columns that are just an integer ID, except for "instance_ID"
         # TODO determine why "Unnamed: 0" appears
-        merged.drop(columns=["class_ID", "instance_ID", "Unnamed: 0"], inplace=True)
+        merged.drop(columns=["class_ID", "Unnamed: 0"], inplace=True)
 
         # Save the data back out with the updated information
         merged.to_file(projections_to_geospatial_savefilename)

--- a/geograypher/entrypoints/project_detections.py
+++ b/geograypher/entrypoints/project_detections.py
@@ -1,7 +1,9 @@
 import os
 from pathlib import Path
 
+import geopandas as gpd
 import numpy as np
+import pandas as pd
 from imageio import imread
 from scipy.sparse import load_npz, save_npz
 
@@ -80,9 +82,12 @@ def project_detections(
         )
         # Infer the image shape from the first image in the folder
         if image_shape is None:
-            image_filename_list = list(Path(image_folder).glob("*.*"))
+            image_filename_list = sorted(list(Path(image_folder).glob("*.*")))
             if len(image_filename_list) > 0:
-                image_shape = imread(image_filename_list[0]).shape[:2]
+                first_file = image_filename_list[0]
+                print(f"loading image shape from {first_file}")
+                first_image = imread(first_file)
+                image_shape = first_image.shape[:2]
             else:
                 raise ValueError(
                     f"No image_shape provided and folder of images {image_folder} was empty"
@@ -96,6 +101,16 @@ def project_detections(
             **segmentor_kwargs,
         )
 
+        # If a file is provided for the projections, save the detection info alongside it
+        if projections_to_mesh_filename is not None:
+            # Export the per-image detection information as one standardized file
+            detection_info_file = Path(
+                projections_to_mesh_filename.parent,
+                projections_to_mesh_filename.stem + "_detection_info.csv",
+            )
+            print(f"Saving detction info to {detection_info_file}")
+            detections_predictor.save_detection_data(detection_info_file)
+
         # Wrap the camera set so that it returns the detections rather than the original images
         detections_camera_set = SegmentorPhotogrammetryCameraSet(
             camera_set, segmentor=detections_predictor
@@ -105,7 +120,6 @@ def project_detections(
             cameras=detections_camera_set, n_classes=detections_predictor.num_classes
         )
 
-        # If a file is provided, save the
         if projections_to_mesh_filename is not None:
             # Export the per-face texture to an npz file, since it's a sparse array
             ensure_containing_folder(projections_to_mesh_filename)
@@ -130,13 +144,40 @@ def project_detections(
                 raise ValueError("No projections_to_mesh_savefilename provided")
             elif os.path.isfile(projections_to_mesh_filename):
                 aggregated_projections = load_npz(projections_to_mesh_filename)
+                detection_info_file = Path(
+                    projections_to_mesh_filename.parent,
+                    projections_to_mesh_filename.stem + "_detection_info.csv",
+                )
+                detection_info = pd.read_csv(detection_info_file)
             else:
                 raise FileNotFoundError(
                     f"projections_to_mesh_filename {projections_to_mesh_filename} not found"
                 )
+        else:
+            detection_info = detections_predictor.get_all_detections()
+
         # Convert the per-face labels to geospatial coordinates. Optionally vis and/or export
         mesh.export_face_labels_vector(
             face_labels=aggregated_projections,
             export_file=projections_to_geospatial_savefilename,
             vis=vis_geodata,
         )
+
+        projected_geo_data = gpd.read_file(projections_to_geospatial_savefilename)
+        # Merge the two dataframes so the left df's "class_ID" field aligns with the right df's
+        # "instance_ID". This will add back the original data assocaited with each per-image detection
+        # to the projected data.
+        # Add the "_right" suffix to any of the original fields that share a name with the ones in the
+        # projected data
+        merged = projected_geo_data.merge(
+            detection_info,
+            left_on="class_ID",
+            right_on="instance_ID",
+            suffixes=(None, "_right"),
+        )
+        # Drop the columns that are just an integer ID
+        # TODO determine why "Unnamed: 0" appears
+        merged.drop(columns=["class_ID", "instance_ID", "Unnamed: 0"], inplace=True)
+
+        # Save the data back out with the updated information
+        merged.to_file(projections_to_geospatial_savefilename)

--- a/geograypher/entrypoints/project_detections.py
+++ b/geograypher/entrypoints/project_detections.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -85,7 +86,7 @@ def project_detections(
             image_filename_list = sorted(list(Path(image_folder).glob("*.*")))
             if len(image_filename_list) > 0:
                 first_file = image_filename_list[0]
-                print(f"loading image shape from {first_file}")
+                logging.info(f"loading image shape from {first_file}")
                 first_image = imread(first_file)
                 image_shape = first_image.shape[:2]
             else:
@@ -108,7 +109,7 @@ def project_detections(
                 projections_to_mesh_filename.parent,
                 projections_to_mesh_filename.stem + "_detection_info.csv",
             )
-            print(f"Saving detction info to {detection_info_file}")
+            logging.info(f"Saving detection info to {detection_info_file}")
             detections_predictor.save_detection_data(detection_info_file)
 
         # Wrap the camera set so that it returns the detections rather than the original images

--- a/geograypher/predictors/derived_segmentors.py
+++ b/geograypher/predictors/derived_segmentors.py
@@ -10,6 +10,7 @@ from skimage.transform import resize
 
 from geograypher.constants import PATH_TYPE
 from geograypher.predictors import Segmentor
+from geograypher.utils.files import ensure_containing_folder
 
 
 class BrightnessSegmentor(Segmentor):
@@ -169,6 +170,13 @@ class TabularRectangleSegmentor(Segmentor):
             labels_df[image_path_key] = image_path_without_ext
 
         return labels_df
+
+    def get_all_detections(self):
+        return self.labels_df
+
+    def save_detection_data(self, output_csv_file: PATH_TYPE):
+        ensure_containing_folder(output_csv_file)
+        self.labels_df.to_csv(output_csv_file)
 
     def get_corners(self, data, as_int=True):
         if self.split_bbox:

--- a/geograypher/predictors/derived_segmentors.py
+++ b/geograypher/predictors/derived_segmentors.py
@@ -171,10 +171,18 @@ class TabularRectangleSegmentor(Segmentor):
 
         return labels_df
 
-    def get_all_detections(self):
+    def get_all_detections(self) -> pd.DataFrame:
+        """Return the aggregated detections dataframe"""
         return self.labels_df
 
     def save_detection_data(self, output_csv_file: PATH_TYPE):
+        """Save the aggregated detections to a file
+
+        Args:
+            output_csv_file (PATH_TYPE):
+                A path to a CSV file to save the detections to. The containing folder will be
+                created if needed.
+        """
         ensure_containing_folder(output_csv_file)
         self.labels_df.to_csv(output_csv_file)
 


### PR DESCRIPTION
Often, pre-image object detectors predict information such as the class of the object and an associated confidence. This data, as well as the image that the detection was produced from when these detections were projected into geospatial coordinates. This PR merges this data back in to the geospatial projections.