### PR TITLE
Compute camera angle off-nadir

### DIFF
--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -50,6 +50,7 @@ class PhotogrammetryCamera:
         image_height: int,
         distortion_params: Dict[str, float] = {},
         lon_lat: Union[None, Tuple[float, float]] = None,
+        local_to_epsg_4978_transform: Union[np.array, None] = None,
     ):
         """Represents the information about one camera location/image as determined by photogrammetry
 
@@ -73,6 +74,7 @@ class PhotogrammetryCamera:
         self.image_width = image_width
         self.image_height = image_height
         self.distortion_params = distortion_params
+        self.local_to_epsg_4978_transform = local_to_epsg_4978_transform
 
         if lon_lat is None:
             self.lon_lat = (None, None)
@@ -536,6 +538,7 @@ class PhotogrammetryCameraSet:
         image_folder: PATH_TYPE = None,
         sensor_IDs: List[int] = None,
         validate_images: bool = False,
+        local_to_epsg_4978_transform: Union[np.array, None] = None,
     ):
         """_summary_
 
@@ -622,7 +625,11 @@ class PhotogrammetryCameraSet:
                 continue
 
             new_camera = PhotogrammetryCamera(
-                image_filename, cam_to_world_transform, lon_lat=lon_lat, **sensor_params
+                image_filename,
+                cam_to_world_transform,
+                lon_lat=lon_lat,
+                local_to_epsg_4978_transform=local_to_epsg_4978_transform,
+                **sensor_params,
             )
             self.cameras.append(new_camera)
 

--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -214,13 +214,23 @@ class PhotogrammetryCamera:
             else tuple(self.cam_to_world_transform[0:2, 3])
         )
 
-    def get_camera_view_angle(self, in_deg=True):
-        # This is the origin, a point at one unit along the principal axis, a point one unit up (-Y), and a point one unit right (+X)
+    def get_camera_view_angle(self, in_deg: bool = True) -> tuple:
+        """Get the off-nadir pitch and yaw angles, computed geometrically from the photogrammtery result
+
+        Args:
+            in_deg (bool, optional): Return the angles in degrees rather than radians. Defaults to True.
+
+        Returns:
+            tuple: (pitch-from-nadir, yaw-from-nadir). Units are defined by in_deg parameter
+        """
+        # This is the origin, a point at one unit along the principal axis, a point one unit
+        # up (-Y), and a point one unit right (+X)
         points_in_camera_frame = np.array(
             [[0, 0, 0, 1], [0, 0, 1, 1], [0, -1, 0, 1], [1, 0, 0, 1]]
         ).T
 
-        # Transform the points first into the world frame and then into the earth-centered, earth-fixed frame
+        # Transform the points first into the world frame and then into the earth-centered,
+        # earth-fixed frame
         points_in_ECEF = (
             self.local_to_epsg_4978_transform
             @ self.cam_to_world_transform
@@ -230,7 +240,6 @@ class PhotogrammetryCamera:
         points_in_ECEF = points_in_ECEF[:-1].T
         # Convert to shapely points
         points_in_ECEF = [Point(*point) for point in points_in_ECEF]
-
         # Convert to a dataframe
         points_in_ECEF = gpd.GeoDataFrame(
             geometry=points_in_ECEF, crs=EARTH_CENTERED_EARTH_FIXED_CRS
@@ -240,13 +249,17 @@ class PhotogrammetryCamera:
         points_in_lat_lon = points_in_ECEF.to_crs(LAT_LON_CRS)
         # Convert to a local projected CRS
         points_in_projected_CRS = ensure_projected_CRS(points_in_lat_lon)
+        # Extract the geometry
         points_in_projected_CRS = np.array(
             [[p.x, p.y, p.z] for p in points_in_projected_CRS.geometry]
         )
+
+        # Compute three vectors starting at the camera origin
         view_vector = points_in_projected_CRS[1] - points_in_projected_CRS[0]
         up_vector = points_in_projected_CRS[2] - points_in_projected_CRS[0]
         right_vector = points_in_projected_CRS[3] - points_in_projected_CRS[0]
 
+        # The nadir vector points straight down
         NADIR_VEC = np.array([0, 0, -1])
 
         # For pitch, project the view vector onto the plane defined by the up vector and the nadir
@@ -262,8 +275,10 @@ class PhotogrammetryCamera:
         pitch_angle = angle_between(pitch_projection_view_vec, NADIR_VEC)
         yaw_angle = angle_between(yaw_projection_view_vec, NADIR_VEC)
 
+        # Return in degrees if requested
         if in_deg:
             return (np.rad2deg(pitch_angle), np.rad2deg(yaw_angle))
+        # Return in radians
         return (pitch_angle, yaw_angle)
 
     def check_projected_in_image(
@@ -750,7 +765,15 @@ class PhotogrammetryCameraSet:
     def get_image_by_index(self, index: int, image_scale: float = 1.0) -> np.ndarray:
         return self[index].get_image(image_scale=image_scale)
 
-    def get_camera_view_angles(self, in_deg=True):
+    def get_camera_view_angles(self, in_deg: bool = True) -> List[Tuple[float]]:
+        """Compute the pitch and yaw off-nadir for all cameras in the set
+
+        Args:
+            in_deg (bool, optional): Return the angles in degrees rather than radians. Defaults to True.
+
+        Returns:
+            List[Tuple[float]]: A list of (pitch, yaw) tuples for each camera.
+        """
         return [
             camera.get_camera_view_angle(in_deg=in_deg)
             for camera in tqdm(self.cameras, desc="Computing view angles")

--- a/geograypher/cameras/derived_cameras.py
+++ b/geograypher/cameras/derived_cameras.py
@@ -125,6 +125,7 @@ class MetashapeCameraSet(PhotogrammetryCameraSet):
             image_folder=image_folder,
             sensor_IDs=sensor_IDs,
             validate_images=validate_images,
+            local_to_epsg_4978_transform=chunk_to_epsg4327,
         )
 
 

--- a/geograypher/utils/geometric.py
+++ b/geograypher/utils/geometric.py
@@ -103,3 +103,38 @@ def get_scale_from_transform(transform: typing.Union[np.ndarray, None]):
     transform_determinant = np.linalg.det(transform[:3, :3])
     scale_factor = np.cbrt(transform_determinant)
     return scale_factor
+
+
+def unit_vector(vector):
+    """Returns the unit vector of the vector."""
+    return vector / np.linalg.norm(vector)
+
+
+# https://stackoverflow.com/questions/2827393/angles-between-two-n-dimensional-vectors-in-python
+def angle_between(v1, v2):
+    """Returns the angle in radians between vectors 'v1' and 'v2'::
+
+    >>> angle_between((1, 0, 0), (0, 1, 0))
+    1.5707963267948966
+    >>> angle_between((1, 0, 0), (1, 0, 0))
+    0.0
+    >>> angle_between((1, 0, 0), (-1, 0, 0))
+    3.141592653589793
+    """
+    v1_u = unit_vector(v1)
+    v2_u = unit_vector(v2)
+    return np.arccos(np.clip(np.dot(v1_u, v2_u), -1.0, 1.0))
+
+
+def orthogonal_projection(v1, v2):
+    # component of v2 along v1
+    scalar = np.dot(v1, v2) / np.linalg.norm(v1) ** 2
+    return scalar * v1
+
+
+def projection_onto_plane(v1, e1, e2):
+    # Compute the projection of vector v1 onto the plane defined by e1, e2
+    plane_normal = np.cross(e1, e2)
+    out_of_plane_projection = orthogonal_projection(plane_normal, v1)
+    in_plane_projection = v1 - out_of_plane_projection
+    return in_plane_projection


### PR DESCRIPTION
This uses the photogrammetry result to compute a pitch and yaw off-nadir. The first step is define four points in the camera coordinate system, representing the camera origin, and one unit forward, up, and right. Then, using matrix operations, these points are projected first into the world coordinate frame and then the earth-centered, earth-fixed frame (ECEF). From here, geospatial operations are used to convert from ECEF to the appropriate projected CRS for that location. Then the angle from horizonal is computed for both pitch and yaw.

Closes #148 