### PR TITLE
Update segmentor entrypoint and skip null tiles

### DIFF
--- a/geograypher/cameras/derived_cameras.py
+++ b/geograypher/cameras/derived_cameras.py
@@ -48,7 +48,7 @@ class MetashapeCameraSet(PhotogrammetryCameraSet):
         image_folder: PATH_TYPE,
         original_image_folder: typing.Optional[PATH_TYPE] = None,
         validate_images: bool = False,
-        default_sensor_params: dict = {"cx":0.0, "cy":0.0},
+        default_sensor_params: dict = {"cx": 0.0, "cy": 0.0},
     ):
         """Parse the information about the camera intrinsics and extrinsics
 

--- a/geograypher/entrypoints/orthomosaic_predictions.py
+++ b/geograypher/entrypoints/orthomosaic_predictions.py
@@ -3,8 +3,8 @@ import logging
 from pathlib import Path
 
 from geograypher.predictors.ortho_segmentor import (
-    write_chips,
     assemble_tiled_predictions,
+    write_chips,
 )
 
 

--- a/geograypher/entrypoints/orthomosaic_predictions.py
+++ b/geograypher/entrypoints/orthomosaic_predictions.py
@@ -21,12 +21,7 @@ def parse_args():
     parser.add_argument("--vector-label-file", help="Path to vector label file.")
     parser.add_argument(
         "--vector-label-column",
-        help="Which column in the vector data to use as the label. This column should be integer values or `vector-label-remap` should be set to remap to integers. If unset the index will be used.",
-    )
-    parser.add_argument(
-        "--vector-label-remap",
-        help="A dictionary mapping from the values in the `vector-label-column` of `vector-label-file` to integer values.",
-        type=dict,
+        help="Which column in the vector data to use as the label. This column should be integer values. If unset the index will be used.",
     )
     parser.add_argument(
         "--write-empty-tiles",
@@ -101,7 +96,6 @@ if __name__ == "__main__":
             chip_stride=int(args.training_stride_fraction * args.chip_size),
             label_vector_file=args.vector_label_file,
             label_column=args.vector_label_column,
-            label_remap=args.vector_label_remap,
             write_empty_tile=args.write_empty_tiles,
         )
 

--- a/geograypher/entrypoints/orthomosaic_predictions.py
+++ b/geograypher/entrypoints/orthomosaic_predictions.py
@@ -2,7 +2,10 @@ import argparse
 import logging
 from pathlib import Path
 
-from geograypher.predictors import OrthoSegmentor
+from geograypher.predictors.ortho_segmentor import (
+    write_chips,
+    assemble_tiled_predictions,
+)
 
 
 def parse_args():
@@ -14,17 +17,22 @@ def parse_args():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
-    parser.add_argument("raster_image_file", help="Path to raster tile")
+    parser.add_argument("raster_file", help="Path to raster tile")
+    parser.add_argument("--vector-label-file", help="Path to vector label file.")
     parser.add_argument(
-        "--vector-label-file",
-        help="Path to vector label file. Cannot be used with --raster-label-file",
+        "--vector-label-column",
+        help="Which column in the vector data to use as the label. This column should be integer values or `vector-label-remap` should be set to remap to integers. If unset the index will be used.",
     )
     parser.add_argument(
-        "--raster-label-file",
-        help="Path to raster label file. Cannot be used with --vector-label-file",
+        "--vector-label-remap",
+        help="A dictionary mapping from the values in the `vector-label-column` of `vector-label-file` to integer values.",
+        type=dict,
     )
-
-    parser.add_argument("--class-names", nargs="+")
+    parser.add_argument(
+        "--write-empty-tiles",
+        action="store_true",
+        help="Write out training tiles that contain no labeled information",
+    )
 
     parser.add_argument(
         "--chip-size", type=int, default=2048, help="Size of chips in pixels"
@@ -43,13 +51,6 @@ def parse_args():
     )
 
     parser.add_argument(
-        "--brightness-multiplier",
-        type=float,
-        default=1.0,
-        help="Multiplier on chip brightness",
-    )
-
-    parser.add_argument(
         "--training-chips-folder",
         type=Path,
         help="Run chipping for training and export to this folder",
@@ -64,7 +65,6 @@ def parse_args():
         type=Path,
         help="Run aggregation using chipts from this folder",
     )
-    parser.add_argument("--class-names", nargs="+")
     parser.add_argument(
         "--aggregated-savefile",
         type=Path,
@@ -92,29 +92,26 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=args.log_level.upper())
 
-    logging.info("Loading data for ortho segmentor class")
-    ortho_seg = OrthoSegmentor(
-        raster_input_file=args.raster_image_file,
-        vector_label_file=args.vector_label_file,
-        raster_label_file=args.raster_label_file,
-        class_names=args.class_names,
-        chip_size=args.chip_size,
-        training_stride=int(args.training_stride_fraction * args.chip_size),
-        inference_stride=int(args.inference_stride_fraction * args.chip_size),
-        class_names=args.class_names,
-    )
-
     if args.training_chips_folder is not None:
         logging.info(f"Writing training chips to {args.training_chips_folder}")
-        ortho_seg.write_training_chips(
-            args.training_chips_folder, brightness_multiplier=args.brightness_multiplier
+        write_chips(
+            raster_file=args.raster_file,
+            output_folder=args.training_chips_folder,
+            chip_size=args.chip_size,
+            chip_stride=int(args.training_stride_fraction * args.chip_size),
+            label_vector_file=args.vector_label_file,
+            label_column=args.vector_label_column,
+            label_remap=args.vector_label_remap,
+            write_empty_tile=args.write_empty_tiles,
         )
 
     if args.inference_chips_folder is not None:
         logging.info(f"Writing inference chips to {args.inference_chips_folder}")
-        ortho_seg.write_inference_chips(
-            args.inference_chips_folder,
-            brightness_multiplier=args.brightness_multiplier,
+        write_chips(
+            raster_file=args.raster_file,
+            output_folder=args.inference_chips_folder,
+            chip_size=args.chip_size,
+            chip_stride=int(args.inference_stride_fraction * args.chip_size),
         )
 
     if args.prediction_chips_folder is not None:
@@ -126,8 +123,9 @@ if __name__ == "__main__":
                 else f" and saving to {args.aggregated_savefile}"
             )
         )
-        ortho_seg.assemble_tiled_predictions(
-            sorted(args.prediction_chips_folder.glob("*")),
+        assemble_tiled_predictions(
+            raster_input_file=args.raster_file,
+            pred_files=sorted(args.prediction_chips_folder.glob("*")),
             class_savefile=args.aggregated_savefile,
             downweight_edge_frac=args.downweight_edge_frac,
         )

--- a/geograypher/predictors/ortho_segmentor.py
+++ b/geograypher/predictors/ortho_segmentor.py
@@ -102,12 +102,14 @@ def write_chips(
     label_vector_file=None,
     label_column=None,
     label_remap=None,
+    write_empty_tile=False,
     drop_transparency=True,
     remove_old=True,
     output_suffix=".JPG",
     ROI_file=None,
     background_ind=NULL_TEXTURE_INT_VALUE,
 ):
+    # Remove the existing directory
     if remove_old and os.path.isdir(output_folder):
         shutil.rmtree(output_folder)
 
@@ -184,6 +186,13 @@ def write_chips(
                     fill=background_ind,
                 )
                 labels_raster = labels_raster.astype(np.uint8)
+                # See if we should skip this tile since it's only background data
+                if not write_empty_tile and np.all(
+                    labels_raster == NULL_TEXTURE_INT_VALUE
+                ):
+                    continue
+
+                # Write out the label
                 output_file_name = Path(
                     labels_folder,
                     get_str_from_window(


### PR DESCRIPTION
The existing entrypoint used an outdate interface that relied on the `OrthoSegmentor` class which has been since deprecated and converted to individual functions.