### PR TITLE
Rescale label image to float [0,1] in composite

### DIFF
--- a/geograypher/utils/visualization.py
+++ b/geograypher/utils/visualization.py
@@ -144,6 +144,10 @@ def create_composite(
         # Rescale to float range and implicitly cast
         RGB_image = RGB_image / 255
 
+    if label_image.dtype == np.uint8:
+        # Rescale to float range and implicitly cast
+        label_image = label_image / 255
+
     if not (label_image.ndim == 3 and label_image.shape[2] == 3):
         # If it's a one channel image make it not have a channel dim
         label_image = np.squeeze(label_image)


### PR DESCRIPTION
Rendering an RGB textured mesh was having problems because this check wasn't in place