### PR TITLE
Add original_image_folder argument to entrypoints

### DIFF
--- a/geograypher/entrypoints/aggregate_images.py
+++ b/geograypher/entrypoints/aggregate_images.py
@@ -52,8 +52,8 @@ def aggregate_images(
         label_folder (PATH_TYPE):
             Path to the folder of labels to be aggregated onto the mesh. Must be in the same
             structure as the images
-        original_images_folder (typing.Union[PATH_TYPE, None], optional):
-            Where the images where when photogrammetry was run. Metashape saves imagenames with an
+        original_image_folder (typing.Union[PATH_TYPE, None], optional):
+            Where the images were when photogrammetry was run. Metashape saves imagenames with an
             absolute path which can cause issues. If this argument is provided, this path is removed
             from the start of each image file name, which allows the camera set to be used with a
             moved folder of images specified by `image_folder`. Defaults to None.

--- a/geograypher/entrypoints/render_labels.py
+++ b/geograypher/entrypoints/render_labels.py
@@ -53,8 +53,8 @@ def render_labels(
             See TexturedPhotogrammetryMesh.load_texture
         render_savefolder (PATH_TYPE):
             Where to save the rendered labels
-        original_images_folder (typing.Union[PATH_TYPE, None], optional):
-            Where the images where when photogrammetry was run. Metashape saves imagenames with an
+        original_image_folder (typing.Union[PATH_TYPE, None], optional):
+            Where the images were when photogrammetry was run. Metashape saves imagenames with an
             absolute path which can cause issues. If this argument is provided, this path is removed
             from the start of each image file name, which allows the camera set to be used with a
             moved folder of images specified by `image_folder`. Defaults to None.


### PR DESCRIPTION
This exposes an optional argument of the `CameraSet` that allows it to deal with Metashape exports that encode an absolute path for the image locations.