### PR TITLE
Support saving renders as TIF files

### DIFF
--- a/geograypher/entrypoints/render_labels.py
+++ b/geograypher/entrypoints/render_labels.py
@@ -93,7 +93,8 @@ def render_labels(
             If set, break the camera set and mesh into this many clusters before rendering. This is
             useful for large meshes that are otherwise very slow. Defaults to None.
         cast_to_uint8 (bool, optional):
-            If True, cast the rendered labels to uint8 & save as PNG. If False, it is saved as TIF files. Defaults to True.
+            If True, cast the rendered labels to uint8. If False, it is cast to uint16 or uint32, if not saved as .npy.
+            Defaults to True.
         save_as_npy (bool, optional):
             If True, save the rendered labels are float64 and saved as numpy arrays. Defaults to False.
         mesh_vis (typing.Union[PATH_TYPE, None])

--- a/geograypher/entrypoints/render_labels.py
+++ b/geograypher/entrypoints/render_labels.py
@@ -37,6 +37,8 @@ def render_labels(
     render_image_scale: float = 1,
     mesh_downsample: float = 1,
     n_render_clusters: typing.Union[int, None] = None,
+    cast_to_uint8: bool = True,
+    save_as_npy: bool = False,
     vis: bool = False,
     mesh_vis_file: typing.Union[PATH_TYPE, None] = None,
     labels_vis_folder: typing.Union[PATH_TYPE, None] = None,
@@ -90,6 +92,10 @@ def render_labels(
         n_render_clusters (typing.Union[int, None]):
             If set, break the camera set and mesh into this many clusters before rendering. This is
             useful for large meshes that are otherwise very slow. Defaults to None.
+        cast_to_uint8 (bool, optional):
+            If True, cast the rendered labels to uint8 & save as PNG. If False, it is saved as TIF files. Defaults to True.
+        save_as_npy (bool, optional):
+            If True, save the rendered labels are float64 and saved as numpy arrays. Defaults to False.
         mesh_vis (typing.Union[PATH_TYPE, None])
             Path to save the visualized mesh instead of showing it interactively. Only applicable if vis=True. Defaults to None.
         labels_vis (typing.Union[PATH_TYPE, None])
@@ -174,6 +180,8 @@ def render_labels(
         save_native_resolution=True,
         output_folder=render_savefolder,
         make_composites=False,
+        cast_to_uint8=cast_to_uint8,
+        save_as_npy=save_as_npy,
         **render_kwargs,
     )
 

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -2064,8 +2064,8 @@ class TexturedPhotogrammetryMesh:
                 raw label
             cast_to_uint8: (bool, optional):
                 cast the float valued data to unit8 for saving efficiency. May dramatically increase
-                efficiency due to png compression
-            sava_as_npy (bool, optional):
+                efficiency due to png compression. Saves as png unless save_as_npy is specifued as True.
+            save_as_npy (bool, optional):
                 Save the rendered images as numpy arrays rather than images. Defaults to False.
             uint8_value_for_null_texture (np.uint8, optional):
                 What value to assign for values that can't be represented as unsigned 8-bit data.
@@ -2158,15 +2158,16 @@ class TexturedPhotogrammetryMesh:
 
             # This may create nested folders in the output dir
             ensure_containing_folder(output_filename)
-            if rendered.dtype == np.uint8:
+
+            if save_as_npy is True:
+                output_filename = str(output_filename.with_suffix(".npy"))
+                # Save the image
+                np.save(output_filename, rendered)
+            elif rendered.dtype == np.uint8:
                 output_filename = str(output_filename.with_suffix(".png"))
 
                 # Save the image
                 skimage.io.imsave(output_filename, rendered, check_contrast=False)
-            elif save_as_npy is True:
-                output_filename = str(output_filename.with_suffix(".npy"))
-                # Save the image
-                np.save(output_filename, rendered)
             else:
                 output_filename = str(output_filename.with_suffix(".tif"))
                 rendered = np.squeeze(rendered)

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -2166,6 +2166,7 @@ class TexturedPhotogrammetryMesh:
             else:
                 # Save image as TIF
                 output_filename = str(output_filename.with_suffix(".tif"))
+                # Remove singleton channel dimension (1, H, W) -> (H, W) to save single-channel TIF
                 rendered = np.squeeze(rendered)
                 # If cast_to_uint8 is True, rendered is already in uint8
                 if cast_to_uint8 is False:

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -2179,4 +2179,3 @@ class TexturedPhotogrammetryMesh:
 
                 # Save the image
                 skimage.io.imsave(output_filename, rendered, compression="deflate")
-

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -2177,4 +2177,9 @@ class TexturedPhotogrammetryMesh:
                         rendered = rendered.astype(np.uint32)
 
                 # Save the image
-                skimage.io.imsave(output_filename, rendered, compression="deflate", check_contrast=False)
+                skimage.io.imsave(
+                    output_filename,
+                    rendered,
+                    compression="deflate",
+                    check_contrast=False,
+                )

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -2064,7 +2064,7 @@ class TexturedPhotogrammetryMesh:
                 raw label
             cast_to_uint8: (bool, optional):
                 cast the float valued data to unit8 for saving efficiency. May dramatically increase
-                efficiency due to png compression. Saves as png unless save_as_npy is specifued as True.
+                efficiency due to png compression. Saves as png unless save_as_npy is specified as True.
             save_as_npy (bool, optional):
                 Save the rendered images as numpy arrays rather than images. Defaults to False.
             uint8_value_for_null_texture (np.uint8, optional):

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -2168,6 +2168,8 @@ class TexturedPhotogrammetryMesh:
                 output_filename = str(output_filename.with_suffix(".tif"))
                 # Remove singleton channel dimension (1, H, W) -> (H, W) to save single-channel TIF
                 rendered = np.squeeze(rendered)
+                # TODO: Consider supporting TIF files with float data (like CHM renders) by adding a separate flag.
+                # Evaluate whether this offers more space savings than npy files.
                 # If cast_to_uint8 is True, rendered is already in uint8
                 if cast_to_uint8 is False:
                     # Check if max value in the rendered image is within the range of uint16

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -2064,9 +2064,9 @@ class TexturedPhotogrammetryMesh:
                 raw label
             cast_to_uint8: (bool, optional):
                 cast the float valued data to unit8 for saving efficiency. May dramatically increase
-                efficiency due to png compression. Saves as png unless save_as_npy is specified as True.
+                efficiency due to tif compression. Saves as tif unless save_as_npy is specified as True.
             save_as_npy (bool, optional):
-                Save the rendered images as numpy arrays rather than images. Defaults to False.
+                Save the rendered images as numpy arrays rather than TIF images. Defaults to False.
             uint8_value_for_null_texture (np.uint8, optional):
                 What value to assign for values that can't be represented as unsigned 8-bit data.
                 Defaults to NULL_TEXTURE_INT_VALUE
@@ -2163,20 +2163,18 @@ class TexturedPhotogrammetryMesh:
                 output_filename = str(output_filename.with_suffix(".npy"))
                 # Save the image
                 np.save(output_filename, rendered)
-            elif rendered.dtype == np.uint8:
-                output_filename = str(output_filename.with_suffix(".png"))
-
-                # Save the image
-                skimage.io.imsave(output_filename, rendered, check_contrast=False)
             else:
+                # Save image as TIF
                 output_filename = str(output_filename.with_suffix(".tif"))
                 rendered = np.squeeze(rendered)
-                # Check if max value in the rendered image is within the range of uint16
-                if np.nanmax(rendered) <= np.iinfo(np.uint16).max:
-                    # Cast from float to uint16
-                    rendered = rendered.astype(np.uint16)
-                else:
-                    rendered = rendered.astype(np.uint32)
+                # If cast_to_uint8 is True, rendered is already in uint8
+                if cast_to_uint8 is False:
+                    # Check if max value in the rendered image is within the range of uint16
+                    if np.nanmax(rendered) <= np.iinfo(np.uint16).max:
+                        # Cast from float to uint16
+                        rendered = rendered.astype(np.uint16)
+                    else:
+                        rendered = rendered.astype(np.uint32)
 
                 # Save the image
-                skimage.io.imsave(output_filename, rendered, compression="deflate")
+                skimage.io.imsave(output_filename, rendered, compression="deflate", check_contrast=False)


### PR DESCRIPTION
This PR adds an option to save renders as compressed TIF files since `.npy` files were very large. I have also retained the option to save out `.npy` files. 