### PR TITLE
Change conda process to fix recent pyvista/vtk issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Internal Collaborators please navigate [here](https://docs.openforestobservatory
 Create and activate a conda environment:
 
 ```
-conda create -n geograypher python=3.9 -y
+conda create -n geograypher -c conda-forge python=3.9 -y
 conda activate geograypher
 ```
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -10,7 +10,7 @@ Internal collaborators please navigate [here](https://docs.openforestobservatory
 Create and activate a conda environment:
 
 ```
-conda create -n geograypher python=3.9 -y
+conda create -n geograypher -c conda-forge python=3.9 -y
 conda activate geograypher
 ```
 
@@ -23,7 +23,7 @@ pip install geograypher
 Create and activate a conda environment:
 
 ```
-conda create -n geograypher python=3.9 -y
+conda create -n geograypher -c conda-forge python=3.9 -y
 conda activate geograypher
 ```
 
@@ -40,6 +40,19 @@ poetry install
 ```
 
 You may get the following error when running `pyvista` visualization:
+
+### Common errors
+
+#### Poetry hanging
+If `poetry install` hangs for a long time with no printouts, you can trying disabling the keyring process. poetry by default is trying to access credentials stored in your system keyring (e.g., for private package repositories) and if that isn't set up it can hang.
+
+```
+export PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring
+```
+
+Then re-run `poetry install`.
+
+#### libGL error
 
 ```
 libGL error: MESA-LOADER: failed to open swrast: <CONDA ENV LOCATION>/bin/../lib/libstdc++.so.6: version `GLIBCXX_3.4.30' not found (required by /lib/x86_64-linux-gnu/libLLVM-15.so.1) (search paths /usr/lib/x86_64-linux-gnu/dri:\$${ORIGIN}/dri:/usr/lib/dri, suffix _dri)


### PR DESCRIPTION
These install steps
```
conda create -n pv39 python=3.9 -y
conda activate pv39
pip install pyvista vtk

python3 >
import pyvista as pv
plotter = pv.Plotter()
```
Fail with
```
>>> plotter = pv.Plotter()
2025-08-22 10:52:56.152 (   1.655s) [    754AA0BD6600]vtkXOpenGLRenderWindow.:284    ERR| vtkXOpenGLRenderWindow (0x38da7450): Could not find a decent config
ERROR:root:Could not find a decent config
2025-08-22 10:52:56.153 (   1.656s) [    754AA0BD6600]vtkXOpenGLRenderWindow.:540   WARN| vtkXOpenGLRenderWindow (0x38da7450): Could not find a decent visual
2025-08-22 10:52:56.154 (   1.657s) [    754AA0BD6600] vtkEGLRenderWindow.cxx:391   WARN| vtkEGLRenderWindow (0x38dc6f70): Setting an EGL display to device index: -1 require EGL_EXT_device_base EGL_EXT_platform_device EGL_EXT_platform_base extensions
2025-08-22 10:52:56.155 (   1.657s) [    754AA0BD6600] vtkEGLRenderWindow.cxx:396   WARN| vtkEGLRenderWindow (0x38dc6f70): Attempting to use EGL_DEFAULT_DISPLAY...
2025-08-22 10:52:56.155 (   1.657s) [    754AA0BD6600] vtkEGLRenderWindow.cxx:401   WARN| vtkEGLRenderWindow (0x38dc6f70): Could not initialize a device. Exiting...
2025-08-22 10:52:56.155 (   1.657s) [    754AA0BD6600]vtkOpenGLRenderWindow.c:920   WARN| vtkEGLRenderWindow (0x38dc6f70): Failed to initialize OpenGL functions!
2025-08-22 10:52:56.155 (   1.657s) [    754AA0BD6600]vtkOpenGLRenderWindow.c:939   WARN| vtkEGLRenderWindow (0x38dc6f70): Unable to find a valid OpenGL 3.2 or later implementation. Please update your video card driver to the latest version. If you are using Mesa please make sure you have version 11.2 or later and make sure your driver in Mesa supports OpenGL 3.2 such as llvmpipe or openswr. If you are on windows and using Microsoft remote desktop note that it only supports OpenGL 3.2 with nvidia quadro cards. You can use other remoting software such as nomachine to avoid this issue.
2025-08-22 10:52:56.157 (   1.659s) [    754AA0BD6600]vtkOSOpenGLRenderWindow:152   WARN| libOSMesa not found. It appears that OSMesa is not installed in your system. Please install the OSMesa library from your distribution's package manager.
```
However, these install steps
```
conda create -n pv39 -c conda-forge python=3.9 -y
conda activate pv39
pip install pyvista vtk

python3 >
import pyvista as pv
import vtk
print(pv.version)
print(vtk.vtkVersion().GetVTKVersion())
# Create a simple test mesh
mesh = pv.Sphere()
# Create a plotter
plotter = pv.Plotter()
plotter.add_mesh(mesh, color="cyan", show_edges=True)
# Show the rendering window
plotter.show()
```
Succeed. When I pip freeze both environments, their library versions are perfectly identical. We believe this is because the `conda-forge` python 3.9 version (different compile version) has better UI support somehow.

Broken env
```
$ conda list python | grep python
python                     3.9.23           he99959a_0
```
Working env
```
$ conda list python | grep python
python                     3.9.23           hc30ae73_0_cpython  conda-forge
```