### PR TITLE
Force pyvista texture key to be string

### DIFF
--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -501,7 +501,7 @@ class TexturedPhotogrammetryMesh:
                 self.logger.warn(
                     "Trying to read texture as a scalar from the pyvista mesh:"
                 )
-                texture_array = self.pyvista_mesh[texture]
+                texture_array = self.pyvista_mesh[str(texture)]
                 self.logger.warn("- success")
             except (KeyError, ValueError):
                 self.logger.warn("- failed")


### PR DESCRIPTION
One option for how to provide the mesh texture is a string, specifying the name of a scalar associated with the mesh to use. In most cases with .ply data, this is just "RGB" and "normals", but other formats can encode arbitrary data. The issue was the lookup operation was expecting a string, but instead getting a `pathlib.Path` object when using an entrypoint.