### PR TITLE
Feature/fes/ply camera vis

### DIFF
--- a/geograypher/cameras/cameras.py
+++ b/geograypher/cameras/cameras.py
@@ -462,8 +462,8 @@ class PhotogrammetryCamera:
         Args:
             frustum_scale (float, optional): Size of cameras in world units.
 
-        Returns: A tuple of
-            PolyData: blue mesh of the camera as a frustum with a red face indicating the image top.
+        Returns (PolyData): blue mesh of the camera as a frustum with a
+            red face indicating the image top.
         """
 
         scaled_halfwidth = self.image_width / (self.f * 2)
@@ -481,26 +481,10 @@ class PhotogrammetryCamera:
             np.array(
                 [
                     [0, 0, 0],
-                    [
-                        right,
-                        top,
-                        1,
-                    ],
-                    [
-                        right,
-                        bottom,
-                        1,
-                    ],
-                    [
-                        left,
-                        bottom,
-                        1,
-                    ],
-                    [
-                        left,
-                        top,
-                        1,
-                    ],
+                    [right, top, 1],
+                    [right, bottom, 1],
+                    [left, bottom, 1],
+                    [left, top, 1],
                 ]
             ).T
             * frustum_scale


### PR DESCRIPTION
Allows extracting a ply mesh of the cameras from the CameraSet class instead of just using pyvista visualization.

Testing:

```
from geograypher.cameras.derived_cameras import MetashapeCameraSet
camset = MetashapeCameraSet(camera_file="/tmp/cameras.xml", image_folder="/tmp/", default_sensor_params={"cx": 0.0, "cy": 0.0, "f": 3000})
camset.get_vis_mesh(0.5).save("/tmp/cameras.ply")
```

<img width="1042" height="623" alt="image" src="https://github.com/user-attachments/assets/213cba13-a383-4f82-87ea-4bf2cab71360" />
