### PR TITLE
Convert equirectangular image to synthetic perspective image

### DIFF
--- a/geograypher/utils/image.py
+++ b/geograypher/utils/image.py
@@ -1,6 +1,11 @@
 import piexif
 from PIL import Image
 
+import numpy as np
+from PIL import Image
+import piexif
+from skimage.transform import warp, downscale_local_mean
+
 
 def get_GPS_exif(filename):
     im = Image.open(filename)
@@ -19,3 +24,116 @@ def get_GPS_exif(filename):
     )
     # https://stackoverflow.com/questions/54196347/overwrite-gps-coordinates-in-image-exif-using-python-3-6
     return lon, lat
+
+
+def perspective_from_equirectangular(
+    equi_img,
+    fov_deg=90,
+    yaw_deg=0,
+    pitch_deg=0,
+    output_size=(1440, 1440),
+    warp_order: int = 1,
+    oversample_factor: int = 1,
+):
+    """Convert equirectangular (360) image to a perspective view.
+    Parameters:
+    - equi_img: np.ndarray the equirectangular image
+    - fov_deg: float, horizontal field of view in degrees
+    - yaw_deg: float, rotation around vertical axis (degrees)
+    - pitch_deg: float, rotation around horizontal axis (degrees)
+    - warp_order: int, order of polynomal interpolation in skimage.transform.warp
+    - oversample_factor: int, sample an image from the original which is larger by this factor to avoid aliasing
+
+    - output_size: (width, height) of output perspective image. Defaults to 1/4 the width.
+    Returns:
+    - PIL.Image of perspective projection
+    """
+    H, W = equi_img.shape[:2]
+
+    # Output image dimensions
+    out_w, out_h = output_size
+
+    # Sample a larger image and downsample to reduce aliasing
+    out_w = int(out_w * oversample_factor)
+    out_h = int(out_h * oversample_factor)
+
+    # FOV and angles in radians
+    fov = np.deg2rad(fov_deg)
+    yaw = np.deg2rad(yaw_deg)
+    pitch = np.deg2rad(pitch_deg)
+
+    # Compute the aspect ratio of the sizes requested
+    aspect_ratio = out_h / out_w
+
+    # Create homogenous image coordinates for the output image
+    x = np.linspace(-np.tan(fov / 2), np.tan(fov / 2), out_w)
+    y = np.linspace(
+        -np.tan(fov / 2) * aspect_ratio, np.tan(fov / 2) * aspect_ratio, out_h
+    )
+
+    xv, yv = np.meshgrid(
+        x, -y
+    )  # invert y for image coordinates to account for array indexing notation
+
+    # The z direction
+    zv = np.ones_like(xv)
+
+    pixel_directions = np.stack((xv, yv, zv), axis=-1)
+    # normalize to unit
+    pixel_directions /= np.linalg.norm(pixel_directions, axis=-1, keepdims=True)
+
+    # Create a matrix to apply the rotation to the direction vectors.
+    # Create yaw rotation matrix (about y)
+    Ry = np.array(
+        [[np.cos(yaw), 0, np.sin(yaw)], [0, 1, 0], [-np.sin(yaw), 0, np.cos(yaw)]]
+    )
+    # Create the pitch rotation matrix (about x)
+    Rx = np.array(
+        [
+            [1, 0, 0],
+            [0, np.cos(pitch), -np.sin(pitch)],
+            [0, np.sin(pitch), np.cos(pitch)],
+        ]
+    )
+    # Compose the two rotations
+    R = Ry @ Rx
+    pixel_directions = pixel_directions @ R.T
+
+    # Convert 3D directions to spherical coordinates
+    # horizontal angle
+    horizontal = np.arctan2(pixel_directions[..., 0], pixel_directions[..., 2])
+    # vertical angle
+    altitude = np.arcsin(pixel_directions[..., 1])
+
+    # Map to equirectangular image coordinates
+    i = (0.5 - altitude / np.pi) * H
+    j = (horizontal / (2 * np.pi) + 0.5) * W
+
+    # Ensure that the coordinates are within the image
+    # TODO note that we could add pixels to the original equirectantular image to handle the wrap
+    # around case. But this is likely a minimal effect.
+    i = np.clip(i, 0, H - 1)
+    j = np.clip(j, 0, W - 1)
+
+    # Note switch in v and u
+    ij = np.stack((i, j), axis=0)
+
+    sampled_perspective = np.stack(
+        [
+            warp(equi_img[..., c], ij, order=warp_order)
+            for c in range(equi_img.shape[2])
+        ],
+        axis=2,
+    )
+    sampled_perspective = (sampled_perspective * 255).astype(np.uint8)
+
+    if oversample_factor > 1:
+        sampled_perspective = downscale_local_mean(
+            sampled_perspective, (oversample_factor, oversample_factor, 1)
+        ).astype(np.uint8)
+
+    # Also save a mask of the pixels being sampled
+    mask = np.zeros(equi_img.shape[:2], dtype=bool)
+    mask[i.astype(int), j.astype(int)] = True
+
+    return Image.fromarray(sampled_perspective), mask

--- a/geograypher/utils/image.py
+++ b/geograypher/utils/image.py
@@ -32,6 +32,7 @@ def perspective_from_equirectangular(
     fov_deg=90,
     yaw_deg=0,
     pitch_deg=0,
+    roll_deg=0,
     output_size=(1440, 1440),
     warp_order: int = 1,
     oversample_factor: int = 1,
@@ -63,6 +64,7 @@ def perspective_from_equirectangular(
     fov = np.deg2rad(fov_deg)
     yaw = np.deg2rad(yaw_deg)
     pitch = np.deg2rad(pitch_deg)
+    roll = np.deg2rad(roll_deg)
 
     # Compute the aspect ratio of the requested image dimensions
     aspect_ratio = out_h / out_w
@@ -84,7 +86,8 @@ def perspective_from_equirectangular(
     # normalize to unit
     pixel_directions /= np.linalg.norm(pixel_directions, axis=-1, keepdims=True)
 
-    rotation_matrix = Rotation.from_euler("yx", [yaw, pitch]).as_matrix()
+    # Seems to correspond to the roll-pitch-yaw convention
+    rotation_matrix = Rotation.from_euler("zyx", [roll, yaw, pitch]).as_matrix()
 
     # Rotate the pixel directions by the rotation matrix
     # The strange convention here is to deal with the fact that pixel_directions is (w, h, 3)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -46,3 +46,15 @@ def test_equi_to_perspective(expected, yaw_deg, pitch_deg):
     assert np.allclose(sample[45, 90, :2], expected[1], atol=1)
     assert np.allclose(sample[90, 45, :2], expected[2], atol=1)
     assert np.allclose(sample[45, 0, :2], expected[3], atol=1)
+
+    ## For debugging, unccoment these
+    ## This shows the indices in the original image from which the perspective image was sampled
+    # f, ax = plt.subplots(1, 2)
+    # cb = ax[0].imshow(sample[:, :, 0])
+    # f.colorbar(cb, ax=ax[0])
+    # ax[0].title.set_text("I values")
+
+    # cb = ax[1].imshow(sample[:, :, 1])
+    # f.colorbar(cb, ax=ax[1])
+    # ax[1].title.set_text("J values")
+    # plt.show()

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,48 @@
+import numpy as np
+from geograypher.utils.image import perspective_from_equirectangular
+import matplotlib.pyplot as plt
+import pytest
+
+
+@pytest.mark.parametrize(
+    "expected,yaw_deg,pitch_deg",
+    (
+        [[(45, 270), (90, 315), (135, 270), (90, 225)], 90, 0],
+        [[(45, 360), (90, 45), (135, 360), (90, 315)], 180, 0],
+    ),
+)
+def test_equi_to_perspective(expected, yaw_deg, pitch_deg):
+    output_size = (91, 91)
+    fov_deg = 90
+    oversample_factor = 1
+    warp_order = 0
+
+    # Create a test equirectangular image where the pixel values are the (i,j) coordinates
+    i_samples = np.arange(180)
+    j_samples = np.arange(360)
+
+    ij = np.meshgrid(i_samples, j_samples, indexing="ij")
+    img = np.stack(
+        ij,
+        axis=-1,
+    )
+    # Divide by 360 to get values in [0, 1] for skimage
+    img = img / 360.0
+
+    sample, _ = perspective_from_equirectangular(
+        equi_img=img,
+        fov_deg=fov_deg,
+        yaw_deg=yaw_deg,
+        pitch_deg=pitch_deg,
+        output_size=output_size,
+        warp_order=warp_order,
+        oversample_factor=oversample_factor,
+    )
+    # Re-scale back to original pixel values
+    sample = sample * 360.0
+
+    # Check the four pixels at the center of each side to see if the value is what was expected
+    assert np.allclose(sample[0, 45, :2], expected[0], atol=1)
+    assert np.allclose(sample[45, 90, :2], expected[1], atol=1)
+    assert np.allclose(sample[90, 45, :2], expected[2], atol=1)
+    assert np.allclose(sample[45, 0, :2], expected[3], atol=1)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -8,7 +8,7 @@ import pytest
     "expected,yaw_deg,pitch_deg",
     (
         [[(45, 270), (90, 315), (135, 270), (90, 225)], 90, 0],
-        [[(45, 360), (90, 45), (135, 360), (90, 315)], 180, 0],
+        [[(45, 0), (90, 45), (135, 0), (90, 315)], 180, 0],
     ),
 )
 def test_equi_to_perspective(expected, yaw_deg, pitch_deg):
@@ -29,7 +29,7 @@ def test_equi_to_perspective(expected, yaw_deg, pitch_deg):
     # Divide by 360 to get values in [0, 1] for skimage
     img = img / 360.0
 
-    sample, _ = perspective_from_equirectangular(
+    sample = perspective_from_equirectangular(
         equi_img=img,
         fov_deg=fov_deg,
         yaw_deg=yaw_deg,


### PR DESCRIPTION
This allows a equirectangular 360 degree image representation to be resampled to for a camera following a traditional perspective camera model. This builds on a script by @FranzEricSchneider, and adds support for specifying the roll and oversampling to reduce anti-aliasing. An initial test case shows that the rendered results corresponds to the expected orientations when checking the four mid-points of the image. I'm going to switch gears since it's useable for my application now but wanted to put this up as a draft first. To finish it, I think it needs the following:
- [ ] Support arbitrary datatypes and data ranges. Currently, the warp functionality rescales `unit8` to `float` in the range (0,1). This is handled in a similar case [here](https://github.com/open-forest-observatory/geograypher/blob/e0d58cfd56853f9da02614d9ee83a51e01766d89/geograypher/cameras/cameras.py#L1145), which should be factored out into a utility.
- [ ] Improve the test cases. More different parameterizations should be tested. To support this, it may be helpful to compute the expected values automatically. This will need to be carefully done though or else the testing code and code which is being tested could fail in similar ways. 