### PR TITLE
Update label rendering to respect arbitrary background ID

### DIFF
--- a/geograypher/constants.py
+++ b/geograypher/constants.py
@@ -23,7 +23,7 @@ INSTANCE_ID_KEY = "instance_ID"
 PRED_CLASS_ID_KEY = "pred_class_ID"
 CLASS_NAMES_KEY = "class_names"
 RATIO_3D_2D_KEY = "ratio_3d_2d"
-NULL_TEXTURE_INT_VALUE = 255
+NULL_TEXTURE_INT_VALUE = 0
 LAT_LON_CRS = pyproj.CRS.from_epsg(4326)
 EARTH_CENTERED_EARTH_FIXED_CRS = pyproj.CRS.from_epsg(4978)
 

--- a/geograypher/entrypoints/render_labels.py
+++ b/geograypher/entrypoints/render_labels.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import typing
 from math import ceil
 from pathlib import Path
@@ -241,12 +242,19 @@ def parse_args():
     parser.add_argument("--cameras-ROI-buffer-radius-meters", default=100, type=float)
     parser.add_argument("--render-image-scale", type=float, default=1)
     parser.add_argument("--mesh-downsample", type=float, default=1)
+    parser.add_argument("--IDs-to-labels", type=Path)
+    parser.add_argument("--n-cameras-per-chunk", type=int)
     parser.add_argument("--cast-to-uint8", action="store_true")
+    parser.add_argument("--save-as-npy", action="store_true")
     parser.add_argument("--vis", action="store_true")
     parser.add_argument("--mesh-vis-file", type=Path)
     parser.add_argument("--labels-vis-folder", type=Path)
 
     args = parser.parse_args()
+    # Load IDs_to_labels from a JSON file if provided
+    if args.IDs_to_labels is not None:
+        with open(args.IDs_to_labels) as f:
+            args.IDs_to_labels = json.load(f)
     return args
 
 

--- a/geograypher/entrypoints/render_labels.py
+++ b/geograypher/entrypoints/render_labels.py
@@ -251,10 +251,6 @@ def parse_args():
     parser.add_argument("--labels-vis-folder", type=Path)
 
     args = parser.parse_args()
-    # Load IDs_to_labels from a JSON file if provided
-    if args.IDs_to_labels is not None:
-        with open(args.IDs_to_labels) as f:
-            args.IDs_to_labels = json.load(f)
     return args
 
 

--- a/geograypher/meshes/derived_meshes.py
+++ b/geograypher/meshes/derived_meshes.py
@@ -122,9 +122,28 @@ class TexturedPhotogrammetryMeshChunked(TexturedPhotogrammetryMesh):
                 else None
             )
 
+            # If this represents a discrete texture we want to make sure the values are not remapped again
+            if self.is_discrete_texture():
+                # Determine unique valuesin this subset
+                unique_submesh_values = np.unique(sub_mesh_texture)
+                # Remove nan
+                unique_submesh_values = (
+                    unique_submesh_values[np.isfinite(unique_submesh_values)]
+                    if len(unique_submesh_values) > 0
+                    else []
+                )
+                # Compute the identity mapping
+                IDs_to_labels = {u: u for u in unique_submesh_values}
+            else:
+                # Otherwise no mapping should be applied
+                IDs_to_labels = None
+
             # Wrap this pyvista mesh in a photogrammetry mesh
             sub_mesh_TPM = TexturedPhotogrammetryMesh(
-                sub_mesh_pv, texture=sub_mesh_texture, input_CRS=self.CRS
+                sub_mesh_pv,
+                texture=sub_mesh_texture,
+                input_CRS=self.CRS,
+                IDs_to_labels=IDs_to_labels,
             )
 
             # Return the submesh as a Textured Photogrammetry Mesh, the subset of cameras, and the

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -432,8 +432,12 @@ class TexturedPhotogrammetryMesh:
                     background_ID=background_ID,
                 )
 
+            # If the IDs_to_labels mapping is identity, don't do the next remapping step
+            is_identity_mapping = list(IDs_to_labels.keys()) == list(
+                IDs_to_labels.values()
+            )
             # If the data is truly continious, there will be no IDs to labels
-            if IDs_to_labels is not None:
+            if IDs_to_labels is not None and not is_identity_mapping:
                 # Create the inverse mapping, returning nan for anything not in it
                 labels_to_IDs = defaultdict(lambda: np.nan)
                 labels_to_IDs.update({v: k for k, v in IDs_to_labels.items()})

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -146,7 +146,7 @@ class TexturedPhotogrammetryMesh:
             with open(IDs_to_labels, "r") as file:
                 IDs_to_labels = json.load(file)
                 IDs_to_labels = {int(id): label for id, label in IDs_to_labels.items()}
-        self.load_texture(texture, texture_column_name, IDs_to_labels=IDs_to_labels)
+        self.load_texture(texture, texture_column_name, IDs_to_labels=IDs_to_labels, background_ID=NULL_TEXTURE_INT_VALUE)
 
     # Setup methods
     def load_mesh(
@@ -381,6 +381,7 @@ class TexturedPhotogrammetryMesh:
         is_vertex_texture: typing.Union[bool, None] = None,
         delete_existing: bool = True,
         update_IDs_to_labels: bool = True,
+        background_ID: int = None
     ):
         """Set the internal texture representation
 
@@ -417,7 +418,7 @@ class TexturedPhotogrammetryMesh:
         else:
             if IDs_to_labels is None:
                 texture_array, derived_IDs_to_labels = ensure_float_labels(
-                    texture_array, full_array=all_discrete_texture_values
+                    texture_array, full_array=all_discrete_texture_values, background_ID=background_ID
                 )
                 # If requested, record these new IDs_to_labels
                 if update_IDs_to_labels:
@@ -487,6 +488,7 @@ class TexturedPhotogrammetryMesh:
         texture: typing.Union[str, PATH_TYPE, np.ndarray, None],
         texture_column_name: typing.Union[None, PATH_TYPE] = None,
         IDs_to_labels: typing.Union[PATH_TYPE, dict, None] = None,
+        background_ID: typing.Union[int, None] = None,
     ):
         """Sets either self.face_texture or self.vertex_texture to an (n_{faces, verts}, m channels) array. Note that the other
            one will be left as None
@@ -506,6 +508,7 @@ class TexturedPhotogrammetryMesh:
             self.set_texture(
                 texture_array=texture,
                 IDs_to_labels=IDs_to_labels,
+                background_ID=background_ID,
             )
         # If the texture is None, try to load it from the mesh
         # Note that this requires us to have not decimated yet
@@ -529,6 +532,7 @@ class TexturedPhotogrammetryMesh:
                 self.set_texture(
                     texture_array,
                     IDs_to_labels=IDs_to_labels,
+                    background_ID=background_ID,
                 )
             else:
                 if IDs_to_labels is not None:
@@ -591,6 +595,7 @@ class TexturedPhotogrammetryMesh:
                 texture_array,
                 all_discrete_texture_values=all_values,
                 IDs_to_labels=IDs_to_labels,
+                background_ID=background_ID,
             )
 
     def select_mesh_ROI(

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -355,9 +355,9 @@ class TexturedPhotogrammetryMesh:
             if self.vertex_texture is not None:
                 return self.standardize_texture(self.vertex_texture)
             elif try_verts_faces_conversion:
-                # TODO this should be fixed since it will perform a breaking conversion
-                self.set_texture(self.face_to_vert_texture(self.face_texture))
-                self.vertex_texture
+                vert_texture = self.face_to_vert_texture(self.face_texture)
+                self.set_texture(vert_texture)
+                return self.vertex_texture
             else:
                 raise ValueError(
                     "Vertex texture not present and conversion was not requested"
@@ -369,7 +369,6 @@ class TexturedPhotogrammetryMesh:
                 face_texture = self.vert_to_face_texture(
                     self.vertex_texture, discrete=self.is_discrete_texture()
                 )
-                # TODO this should be fixed since it will perform a breaking conversion
                 self.set_texture(face_texture)
                 return self.face_texture
             else:
@@ -380,17 +379,17 @@ class TexturedPhotogrammetryMesh:
     def is_discrete_texture(self):
         return self.IDs_to_labels is not None
 
-    def set_texture(
+    def remap_texture(
         self,
         texture_array: np.ndarray,
         IDs_to_labels: typing.Union[None, dict] = None,
         all_discrete_texture_values: typing.Union[typing.List, None] = None,
-        is_vertex_texture: typing.Union[bool, None] = None,
-        delete_existing: bool = True,
         update_IDs_to_labels: bool = True,
         background_ID: int = None,
-    ):
-        """Set the internal texture representation
+    ) -> np.array:
+        """
+        Remap the texture from the initial representation to either continious floats or floats
+        representing discrete integer values. This also sets self.IDs_to_labels
 
         Args:
             texture_array (np.ndarray):
@@ -401,18 +400,14 @@ class TexturedPhotogrammetryMesh:
             all_discrete_texture_values (typing.Union[typing.List, None], optional):
                 Are all the texture values known to be discrete, representing IDs. Computed from
                 the data if not set. Defaults to None.
-            is_vertex_texture (typing.Union[bool, None], optional):
-                Are the texture values supposed to correspond to the vertices. Computed from the
-                data if not set. Defaults to None.
-            delete_existing (bool, optional):
-                Delete the existing texture when the other one (face, vertex) is set. Defaults to True.
             update_IDs_to_labels (bool, optional):
                 Should IDs to labels be updated based on either the provided IDs_to_labels or the
                 derived ones. Defaults to True.
+            background_ID (int, optional):
+                An ID which should not be included in IDs_to_labels
 
-        Raises:
-            ValueError: If the size of the texture doesn't match the number of either faces or vertices
-            ValueError: If the number of faces and vertices are the same and is_vertex_texture isn't set
+        Returns:
+            np.array: remapped texture
         """
         # Ensure that the texture is 2D
         texture_array = self.standardize_texture(texture_array)
@@ -457,7 +452,12 @@ class TexturedPhotogrammetryMesh:
                 # Because the default dict has a default value of zero, any items not in the labels
                 # are given the value of nan. This step can be slow for large textures.
                 texture_array = np.array(
-                    [labels_to_IDs[l] for l in texture_array.squeeze()]
+                    [
+                        labels_to_IDs[l]
+                        for l in tqdm(
+                            texture_array.squeeze(), desc="Remapping labels to IDs"
+                        )
+                    ]
                 )
                 # Reinstate the squeezed dimension
                 texture_array = np.expand_dims(texture_array, axis=1)
@@ -465,6 +465,33 @@ class TexturedPhotogrammetryMesh:
             # If requested, record these IDs to labels
             if update_IDs_to_labels:
                 self.IDs_to_labels = IDs_to_labels
+
+        return texture_array
+
+    def set_texture(
+        self,
+        texture_array: np.ndarray,
+        is_vertex_texture: typing.Union[bool, None] = None,
+        delete_existing: bool = True,
+    ):
+        """Set the internal texture representation
+
+        Args:
+            texture_array (np.ndarray):
+                The array of texture values. The first dimension must be the length of faces or
+                verts. A second dimension is optional.
+            is_vertex_texture (typing.Union[bool, None], optional):
+                Are the texture values supposed to correspond to the vertices. Computed from the
+                data if not set. Defaults to None.
+            delete_existing (bool, optional):
+                Delete the existing texture when the other one (face, vertex) is set. Defaults to True.
+
+        Raises:
+            ValueError: If the size of the texture doesn't match the number of either faces or vertices
+            ValueError: If the number of faces and vertices are the same and is_vertex_texture isn't set
+        """
+        # Ensure that the texture is 2D
+        texture_array = self.standardize_texture(texture_array)
 
         # If it is not specified whether this is a vertex texture, attempt to infer it from the shape
         # TODO consider refactoring to check whether it matches the number of one of them,
@@ -518,16 +545,9 @@ class TexturedPhotogrammetryMesh:
             texture_column_name: The column to use as the label for a vector data input
             IDs_to_labels (typing.Union[None, dict]): Dictionary mapping from integer IDs to string class names
         """
-        # The easy case, a texture is passed in directly
-        if isinstance(texture, np.ndarray):
-            self.set_texture(
-                texture_array=texture,
-                IDs_to_labels=IDs_to_labels,
-                background_ID=background_ID,
-            )
         # If the texture is None, try to load it from the mesh
         # Note that this requires us to have not decimated yet
-        elif texture is None:
+        if texture is None:
             # See if the mesh has a texture, else this will be None
             texture_array = self.pyvista_mesh.active_scalars
 
@@ -541,25 +561,28 @@ class TexturedPhotogrammetryMesh:
                         # This is supposted to be one channel
                         texture_array = texture_array[:, 0].astype(float)
                         # Set any values that are the ignore int value to nan
-                texture_array = texture_array.astype(float)
-                texture_array[texture_array == NULL_TEXTURE_INT_VALUE] = np.nan
-
-                self.set_texture(
-                    texture_array,
-                    IDs_to_labels=IDs_to_labels,
-                    background_ID=background_ID,
-                )
             else:
-                if IDs_to_labels is not None:
-                    self.IDs_to_labels = IDs_to_labels
                 # Assume that no texture will be needed, consider printing a warning
                 self.logger.warn("No texture provided")
-        else:
-            # Try handling all the other supported filetypes
-            texture_array = None
-            all_values = None
 
-            # Name of scalar in the mesh
+                # Still set IDs to labels even if there's no texture
+                if IDs_to_labels is not None:
+                    self.IDs_to_labels = IDs_to_labels
+
+                return
+
+        # Try to parse the texture in many different ways
+        # Default all values to None, since only some approaches provided it
+        all_values = None
+        # Set texture array
+        texture_array = None
+
+        # The easy case, a texture is passed in directly
+        if isinstance(texture, np.ndarray):
+            texture_array = texture
+
+        # The texture is a scalar in the mesh
+        if texture_array is None:
             try:
                 self.logger.warn(
                     "Trying to read texture as a scalar from the pyvista mesh:"
@@ -569,49 +592,51 @@ class TexturedPhotogrammetryMesh:
             except (KeyError, ValueError):
                 self.logger.warn("- failed")
 
-            # Numpy file
-            if texture_array is None:
-                try:
-                    self.logger.warn("Trying to read texture as a numpy file:")
-                    texture_array = np.load(texture, allow_pickle=True)
-                    self.logger.warn("- success")
-                except:
-                    self.logger.warn("- failed")
+        # Numpy file
+        if texture_array is None:
+            try:
+                self.logger.warn("Trying to read texture as a numpy file:")
+                texture_array = np.load(texture, allow_pickle=True)
+                self.logger.warn("- success")
+            except:
+                self.logger.warn("- failed")
 
-            # Vector file
-            if texture_array is None:
-                try:
-                    self.logger.warn("Trying to read texture as vector file:")
-                    # TODO IDs to labels should be used here if set so the computed IDs are aligned with that mapping
-                    texture_array, all_values = self.get_values_for_verts_from_vector(
-                        column_names=texture_column_name,
-                        vector_source=texture,
-                    )
-                    self.logger.warn("- success")
-                except (IndexError, fiona.errors.DriverError):
-                    self.logger.warn("- failed")
+        # Vector file
+        if texture_array is None:
+            try:
+                self.logger.warn("Trying to read texture as vector file:")
+                # TODO IDs to labels should be used here if set so the computed IDs are aligned with that mapping
+                texture_array, all_values = self.get_values_for_verts_from_vector(
+                    column_names=texture_column_name,
+                    vector_source=texture,
+                )
+                self.logger.warn("- success")
+            except (IndexError, fiona.errors.DriverError):
+                self.logger.warn("- failed")
 
-            # Raster file
-            if texture_array is None:
-                try:
-                    # TODO
-                    self.logger.warn("Trying to read as texture as raster file: ")
-                    texture_array = self.get_vert_values_from_raster_file(texture)
-                    self.logger.warn("- success")
-                except:
-                    self.logger.warn("- failed")
+        # Raster file
+        if texture_array is None:
+            try:
+                self.logger.warn("Trying to read as texture as raster file: ")
+                texture_array = self.get_vert_values_from_raster_file(texture)
+                self.logger.warn("- success")
+            except:
+                self.logger.warn("- failed")
 
-            # Error out if not set, since we assume the intent was to have a texture at this point
-            if texture_array is None:
-                raise ValueError(f"Could not load texture for {texture}")
+        # Error out if not set, since we assume the intent was to have a texture at this point
+        if texture_array is None:
+            raise ValueError(f"Could not load texture for {texture}")
 
-            # This will error if something is wrong with the texture that was loaded
-            self.set_texture(
-                texture_array,
-                all_discrete_texture_values=all_values,
-                IDs_to_labels=IDs_to_labels,
-                background_ID=background_ID,
-            )
+        # This will error if something is wrong with the texture that was loaded
+        remapped_texture = self.remap_texture(
+            texture_array=texture_array,
+            IDs_to_labels=IDs_to_labels,
+            all_discrete_texture_values=all_values,
+            update_IDs_to_labels=True,
+            background_ID=background_ID,
+        )
+        # Set the texture
+        self.set_texture(remapped_texture)
 
     def select_mesh_ROI(
         self,
@@ -1561,11 +1586,8 @@ class TexturedPhotogrammetryMesh:
 
         # Optionally apply the texture to the mesh
         if set_mesh_texture:
-            # Set the mesh texture, without updating the previous mapping since it has already been
-            # handled
-            self.set_texture(
-                labels, IDs_to_labels=self.IDs_to_labels, update_IDs_to_labels=False
-            )
+            # Set the mesh texture with the new ground ID added
+            self.set_texture(labels)
 
         return labels
 

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -545,6 +545,12 @@ class TexturedPhotogrammetryMesh:
             texture_column_name: The column to use as the label for a vector data input
             IDs_to_labels (typing.Union[None, dict]): Dictionary mapping from integer IDs to string class names
         """
+        # Try to parse the texture in many different ways
+        # Default all values to None, since only some approaches provided it
+        all_values = None
+        # Set texture array
+        texture_array = None
+
         # If the texture is None, try to load it from the mesh
         # Note that this requires us to have not decimated yet
         if texture is None:
@@ -570,12 +576,6 @@ class TexturedPhotogrammetryMesh:
                     self.IDs_to_labels = IDs_to_labels
 
                 return
-
-        # Try to parse the texture in many different ways
-        # Default all values to None, since only some approaches provided it
-        all_values = None
-        # Set texture array
-        texture_array = None
 
         # The easy case, a texture is passed in directly
         if isinstance(texture, np.ndarray):

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -45,7 +45,7 @@ from geograypher.utils.geospatial import (
     ensure_projected_CRS,
     get_projected_CRS,
 )
-from geograypher.utils.indexing import ensure_float_labels
+from geograypher.utils.indexing import determine_IDs_to_labels
 from geograypher.utils.numeric import compute_3D_triangle_area, fair_mode_non_nan
 from geograypher.utils.visualization import create_composite, create_pv_plotter
 
@@ -355,6 +355,7 @@ class TexturedPhotogrammetryMesh:
             if self.vertex_texture is not None:
                 return self.standardize_texture(self.vertex_texture)
             elif try_verts_faces_conversion:
+                # TODO this should be fixed since it will perform a breaking conversion
                 self.set_texture(self.face_to_vert_texture(self.face_texture))
                 self.vertex_texture
             else:
@@ -368,6 +369,7 @@ class TexturedPhotogrammetryMesh:
                 face_texture = self.vert_to_face_texture(
                     self.vertex_texture, discrete=self.is_discrete_texture()
                 )
+                # TODO this should be fixed since it will perform a breaking conversion
                 self.set_texture(face_texture)
                 return self.face_texture
             else:
@@ -412,8 +414,14 @@ class TexturedPhotogrammetryMesh:
             ValueError: If the size of the texture doesn't match the number of either faces or vertices
             ValueError: If the number of faces and vertices are the same and is_vertex_texture isn't set
         """
-        # Ensure that the texture is 2D and a numpy array
+        # Ensure that the texture is 2D
         texture_array = self.standardize_texture(texture_array)
+
+        # The texture which is set should be either
+        # - an array of floats, representing a continuous quantity
+        # - an array of floats with int values, representing a categorical variable
+        # - - If IDs_to_labels is set, the texture array should be remapping by applying labels-to-IDs mapping
+        # - - If IDs_to_labels is unset, it should be first computed from all unique values. Then applied as above.
 
         if texture_array.ndim == 2 and texture_array.shape[1] != 1:
             # If it is more than one column, it's assumed to be a real-valued
@@ -422,15 +430,15 @@ class TexturedPhotogrammetryMesh:
             self.IDs_to_labels = None
         else:
             if IDs_to_labels is None:
-                texture_array, derived_IDs_to_labels = ensure_float_labels(
-                    texture_array,
-                    full_array=all_discrete_texture_values,
+                # Compute IDs_to_labels from data
+                IDs_to_labels = determine_IDs_to_labels(
+                    texture_array=texture_array,
+                    all_discrete_texture_values=all_discrete_texture_values,
                     background_ID=background_ID,
                 )
-                # If requested, record these new IDs_to_labels
-                if update_IDs_to_labels:
-                    self.IDs_to_labels = derived_IDs_to_labels
-            else:
+
+            # If the data is truly continious, there will be no IDs to labels
+            if IDs_to_labels is not None:
                 # Create the inverse mapping, returning nan for anything not in it
                 labels_to_IDs = defaultdict(lambda: np.nan)
                 labels_to_IDs.update({v: k for k, v in IDs_to_labels.items()})
@@ -442,7 +450,7 @@ class TexturedPhotogrammetryMesh:
                 # Check that the mapping only produces ints
                 if not np.all([isinstance(v, int) for v in labels_to_IDs.values()]):
                     raise ValueError(
-                        "The labels to IDs mapping does not produce only floats"
+                        "The labels to IDs mapping does not produce only ints"
                     )
 
                 # This step updates the texture array from the initial labels to the new IDs.
@@ -454,9 +462,9 @@ class TexturedPhotogrammetryMesh:
                 # Reinstate the squeezed dimension
                 texture_array = np.expand_dims(texture_array, axis=1)
 
-                # If requested, record these IDs to labels
-                if update_IDs_to_labels:
-                    self.IDs_to_labels = IDs_to_labels
+            # If requested, record these IDs to labels
+            if update_IDs_to_labels:
+                self.IDs_to_labels = IDs_to_labels
 
         # If it is not specified whether this is a vertex texture, attempt to infer it from the shape
         # TODO consider refactoring to check whether it matches the number of one of them,
@@ -1544,8 +1552,7 @@ class TexturedPhotogrammetryMesh:
             # If the label names are present, and the class is not already included, add it as the last element
             if ground_ID is None:
                 # Set it to the first unused ID
-                # TODO improve this since it should be the max plus one
-                ground_ID = len(IDs_to_labels)
+                ground_ID = np.max(IDs_to_labels.keys()) + 1
 
         self.add_label(label_name=ground_class_name, label_ID=ground_ID)
 
@@ -1554,9 +1561,11 @@ class TexturedPhotogrammetryMesh:
 
         # Optionally apply the texture to the mesh
         if set_mesh_texture:
-            # TODO look into why this shouldn't update the IDs to labels.
-            # I guess because it may have been initially user-provided.
-            self.set_texture(labels, update_IDs_to_labels=False)
+            # Set the mesh texture, without updating the previous mapping since it has already been
+            # handled
+            self.set_texture(
+                labels, IDs_to_labels=self.IDs_to_labels, update_IDs_to_labels=False
+            )
 
         return labels
 

--- a/geograypher/meshes/meshes.py
+++ b/geograypher/meshes/meshes.py
@@ -146,7 +146,12 @@ class TexturedPhotogrammetryMesh:
             with open(IDs_to_labels, "r") as file:
                 IDs_to_labels = json.load(file)
                 IDs_to_labels = {int(id): label for id, label in IDs_to_labels.items()}
-        self.load_texture(texture, texture_column_name, IDs_to_labels=IDs_to_labels, background_ID=NULL_TEXTURE_INT_VALUE)
+        self.load_texture(
+            texture,
+            texture_column_name,
+            IDs_to_labels=IDs_to_labels,
+            background_ID=NULL_TEXTURE_INT_VALUE,
+        )
 
     # Setup methods
     def load_mesh(
@@ -381,7 +386,7 @@ class TexturedPhotogrammetryMesh:
         is_vertex_texture: typing.Union[bool, None] = None,
         delete_existing: bool = True,
         update_IDs_to_labels: bool = True,
-        background_ID: int = None
+        background_ID: int = None,
     ):
         """Set the internal texture representation
 
@@ -418,7 +423,9 @@ class TexturedPhotogrammetryMesh:
         else:
             if IDs_to_labels is None:
                 texture_array, derived_IDs_to_labels = ensure_float_labels(
-                    texture_array, full_array=all_discrete_texture_values, background_ID=background_ID
+                    texture_array,
+                    full_array=all_discrete_texture_values,
+                    background_ID=background_ID,
                 )
                 # If requested, record these new IDs_to_labels
                 if update_IDs_to_labels:

--- a/geograypher/utils/indexing.py
+++ b/geograypher/utils/indexing.py
@@ -1,4 +1,5 @@
 import logging
+import typing
 
 import numpy as np
 import pandas as pd
@@ -31,78 +32,56 @@ def find_argmax_nonzero_value(
     return argmax
 
 
-def ensure_float_labels(
-    query_array, full_array=None, background_ID=None
-) -> (np.ndarray, dict):
-    if not (background_ID is None or isinstance(background_ID, int)):
-        raise ValueError(
-            f"The background must be None or an int but instead is {background_ID}"
-        )
+def determine_IDs_to_labels(
+    texture_array: np.ndarray,
+    all_discrete_texture_values: typing.Union[typing.List, None] = None,
+    background_ID: int = None,
+):
+    """Return the mapping of unique IDs to labels, or None if values are continous floats
 
-    # Standardizing the type
-    if isinstance(query_array, pd.Series):
-        query_array = query_array.to_numpy()
-    else:
-        query_array = np.array(query_array)
+    Args:
+        texture_array (np.ndarray): _description_
+        IDs_to_labels (typing.Union[None, dict], optional): _description_. Defaults to None.
+        all_discrete_texture_values (typing.Union[typing.List, None], optional): _description_. Defaults to None.
+        background_ID (int, optional): _description_. Defaults to None.
+    """
+    # Check to see if the data is a continious float representation
+    if texture_array.dtype == float:
+        finite_labels = texture_array[np.isfinite(texture_array)]
 
-    # Check if the array is a string or some other object type that is not numeric
-    if query_array.dtype in (str, np.dtype("O")):
-        # Get unique values from full array if provided, or query array if not
-        # Note that if the full array is not provided, the IDs will change based
-        # on what set of the labeled data is indexed
-        unique_values = np.unique(query_array if full_array is None else full_array)
+        # If the data does not approximate integer data, it truly represents a contious quantity. Therefore, return None
+        if not np.allclose(finite_labels, finite_labels.astype(int)):
+            return None
 
-        # Build an output array
-        output_query_array = np.full_like(query_array, fill_value=np.nan, dtype=float)
+    # In this case, it's time to compute IDs to labels
+    # If all the discrete texture values are provided, use that. Otherwise, just use
+    # the texture array values.
+    # TODO, it would be good to eliminate the concept of passing all_discrete_texture_values
+    # and handle that solely with IDs_to_labels
+    unique_values_source = (
+        texture_array
+        if all_discrete_texture_values is None
+        else all_discrete_texture_values
+    )
+    unique_values = np.unique(unique_values_source)
 
-        IDs_to_label = {}
-        # Iterate through and set the values that match to the integer label
-        i = 0
-        for unique_value in unique_values:
-            # If it matches the background ID, increment to skip
-            if i is not None and i == background_ID:
-                i += 1
+    # Build the IDs to labels mapping
 
-            # Skip the background ID
-            output_query_array[query_array == unique_value] = i
-            IDs_to_label[i] = unique_value
-
-            # Increment normally
+    IDs_to_label = {}
+    # Iterate through and set the values that match to the integer label
+    i = 0
+    for unique_value in unique_values:
+        # If it matches the background ID, increment to skip
+        if i is not None and i == background_ID:
             i += 1
 
-        return output_query_array, IDs_to_label
+        # Set the value in the dict
+        IDs_to_label[i] = unique_value
 
-    # This is numeric data, but we want to check if it's representing something
-    # categorical/ordinal
+        # Increment normally
+        i += 1
 
-    # Determine which labels are finite so we can cast them to ints
-    finite_labels = query_array[np.isfinite(query_array)]
-    # See if all labels are approximately ints
-    if np.allclose(finite_labels, finite_labels.astype(int)):
-        # Try to remove any numerical issues by rounding to the ints
-        unique_values = np.unique(
-            np.round(query_array[np.isfinite(query_array)])
-            if full_array is None
-            else np.round(full_array[np.isfinite(full_array)])
-        )
-
-        IDs_to_label = {}
-        i = 0
-        for unique_value in unique_values:
-            # Increment to skip if it matches the background ID
-            if i is not None and i == background_ID:
-                i += 1
-
-            IDs_to_label[i] = unique_value
-            # Increment normally
-            i += 1
-    else:
-        # These are not discrete, so it doesn't make sense to represent them with IDs
-        IDs_to_label = None
-
-    # Cast to float, since that's expected
-    output_query_array = query_array.astype(float)
-    return output_query_array, IDs_to_label
+    return IDs_to_label
 
 
 def inverse_map_interpolation(

--- a/geograypher/utils/indexing.py
+++ b/geograypher/utils/indexing.py
@@ -31,7 +31,10 @@ def find_argmax_nonzero_value(
     return argmax
 
 
-def ensure_float_labels(query_array, full_array=None) -> (np.ndarray, dict):
+def ensure_float_labels(query_array, full_array=None, background_ID=None) -> (np.ndarray, dict):
+    if not (background_ID is None or isinstance(background_ID, int)):
+        raise ValueError(f"The background must be None or an int but instead is {background_ID}")
+
     # Standardizing the type
     if isinstance(query_array, pd.Series):
         query_array = query_array.to_numpy()
@@ -50,9 +53,18 @@ def ensure_float_labels(query_array, full_array=None) -> (np.ndarray, dict):
 
         IDs_to_label = {}
         # Iterate through and set the values that match to the integer label
-        for i, unique_value in enumerate(unique_values):
+        i = 0
+        for unique_value in unique_values:
+            # If it matches the background ID, increment to skip
+            if i is not None and i == background_ID:
+                i += 1
+
+            # Skip the background ID
             output_query_array[query_array == unique_value] = i
             IDs_to_label[i] = unique_value
+
+            # Increment normally
+            i += 1
 
         return output_query_array, IDs_to_label
 
@@ -70,7 +82,16 @@ def ensure_float_labels(query_array, full_array=None) -> (np.ndarray, dict):
             else np.round(full_array[np.isfinite(full_array)])
         )
 
-        IDs_to_label = {i: val for i, val in enumerate(unique_values)}
+        IDs_to_label = {}
+        i = 0
+        for unique_value in unique_values:
+            # Increment to skip if it matches the background ID
+            if i is not None and i == background_ID:
+                i += 1
+
+            IDs_to_label[i] = unique_value
+            # Increment normally
+            i += 1
     else:
         # These are not discrete, so it doesn't make sense to represent them with IDs
         IDs_to_label = None

--- a/geograypher/utils/indexing.py
+++ b/geograypher/utils/indexing.py
@@ -31,9 +31,13 @@ def find_argmax_nonzero_value(
     return argmax
 
 
-def ensure_float_labels(query_array, full_array=None, background_ID=None) -> (np.ndarray, dict):
+def ensure_float_labels(
+    query_array, full_array=None, background_ID=None
+) -> (np.ndarray, dict):
     if not (background_ID is None or isinstance(background_ID, int)):
-        raise ValueError(f"The background must be None or an int but instead is {background_ID}")
+        raise ValueError(
+            f"The background must be None or an int but instead is {background_ID}"
+        )
 
     # Standardizing the type
     if isinstance(query_array, pd.Series):


### PR DESCRIPTION
This changes how the IDs to labels are computed if not user-provided such that the background ID is excluded from the mapping. It appears to be working properly, but a full rewrite of the code that handles the IDs to labels process is probably in order. It's getting very messy.