### PR TITLE
Support cameras with multiple un-registered 'components'

### DIFF
--- a/geograypher/cameras/derived_cameras.py
+++ b/geograypher/cameras/derived_cameras.py
@@ -19,10 +19,17 @@ def update_lists(
     image_filenames,
     sensor_IDs,
     original_image_folder=None,
+    active_component_id=None,
 ):
     transform = camera.find("transform")
     if transform is None:
         # skipping unaligned camera
+        return
+    if (
+        active_component_id is not None
+        and camera.get("component_id") != active_component_id
+    ):
+        # skipping camera that is not part of the active component
         return
     # If valid, parse into numpy array
     cam_to_world_transforms.append(np.fromstring(transform.text, sep=" ").reshape(4, 4))
@@ -86,6 +93,13 @@ class MetashapeCameraSet(PhotogrammetryCameraSet):
         cam_to_world_transforms = []
         sensor_IDs = []
 
+        # Get the transform from the chunk to the earth-centered, earth-fixed (ECEF) frame, along
+        # with the ID of the active component, so cameras belonging to other components can be
+        # excluded below
+        chunk_to_epsg4978, active_component_id = parse_transform_metashape(
+            camera_file=camera_file, return_component_id=True
+        )
+
         cameras = chunk.find("cameras")
         # Iterate over metashape cameras and fill out required information
         for cam_or_group in cameras:
@@ -98,6 +112,7 @@ class MetashapeCameraSet(PhotogrammetryCameraSet):
                         image_filenames,
                         sensor_IDs,
                         original_image_folder=original_image_folder,
+                        active_component_id=active_component_id,
                     )
             else:
                 update_lists(
@@ -107,14 +122,11 @@ class MetashapeCameraSet(PhotogrammetryCameraSet):
                     image_filenames,
                     sensor_IDs,
                     original_image_folder=original_image_folder,
+                    active_component_id=active_component_id,
                 )
 
         # Compute the lat lon using the transforms, because the reference values recorded in the file
         # reflect the EXIF values, not the optimized ones
-
-        # Get the transform from the chunk to the earth-centered, earth-fixed (ECEF) frame
-        chunk_to_epsg4978 = parse_transform_metashape(camera_file=camera_file)
-
         if chunk_to_epsg4978 is not None:
             # Compute the location of each camera in ECEF
             cam_locs_in_epsg4978 = []

--- a/geograypher/utils/parsing.py
+++ b/geograypher/utils/parsing.py
@@ -92,7 +92,7 @@ def parse_transform_metashape(
     components = root.find("chunk").find("components")
 
     # There may be multiple non-registered sets of cameras ("components"). Select the active one,
-    # which should be the largest one.
+    # which corresponds to the one used to generate photogrammetry products.
     active_component_id = components.get("active_id")
     active_component = components.find(f"component[@id='{active_component_id}']")
 

--- a/geograypher/utils/parsing.py
+++ b/geograypher/utils/parsing.py
@@ -70,7 +70,9 @@ def make_4x4_transform(rotation_str: str, translation_str: str, scale_str: str =
     return transform
 
 
-def parse_transform_metashape(camera_file: PATH_TYPE, return_component_id:bool=False):
+def parse_transform_metashape(
+    camera_file: PATH_TYPE, return_component_id: bool = False
+):
     """
     Get the georeferncing transform from a camera file. Note that this corresponds to the active
     component (set of registered cameras).

--- a/geograypher/utils/parsing.py
+++ b/geograypher/utils/parsing.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import numpy as np
 import pyproj
 
+from geograypher.constants import PATH_TYPE
+
 
 def parse_metashape_mesh_metadata(
     mesh_metadata_file: typing.Union[str, Path],
@@ -68,23 +70,42 @@ def make_4x4_transform(rotation_str: str, translation_str: str, scale_str: str =
     return transform
 
 
-def parse_transform_metashape(camera_file):
+def parse_transform_metashape(camera_file: PATH_TYPE, return_component_id:bool=False):
+    """
+    Get the georeferncing transform from a camera file. Note that this corresponds to the active
+    component (set of registered cameras).
+
+
+    Args:
+        camera_file (PATH_TYPE): Path to the camera file
+        return_component_id (bool, optional): Should the active component ID be returned. Defaults to False.
+
+    Returns:
+        np.ndarray: (4, 4) A homogenous transform mapping from cam to world
+        Union[str, None]: The ID of the active component, if requested
+    """
     tree = ET.parse(camera_file)
     root = tree.getroot()
     # first level
     components = root.find("chunk").find("components")
 
-    assert len(components) == 1
-    transform = components.find("component").find("transform")
+    # There may be multiple non-registered sets of cameras ("components"). Select the active one,
+    # which should be the largest one.
+    active_component_id = components.get("active_id")
+    active_component = components.find(f"component[@id='{active_component_id}']")
+
+    transform = active_component.find("transform")
     if transform is None:
-        return None
+        local_to_epgs_4978_transform = None
+    else:
+        rotation = transform.find("rotation").text
+        translation = transform.find("translation").text
+        scale = transform.find("scale").text
 
-    rotation = transform.find("rotation").text
-    translation = transform.find("translation").text
-    scale = transform.find("scale").text
+        local_to_epgs_4978_transform = make_4x4_transform(rotation, translation, scale)
 
-    local_to_epgs_4978_transform = make_4x4_transform(rotation, translation, scale)
-
+    if return_component_id:
+        return local_to_epgs_4978_transform, active_component_id
     return local_to_epgs_4978_transform
 
 


### PR DESCRIPTION
Currently, the camera file is enforced to have only one `component` ([here](https://github.com/open-forest-observatory/geograypher/blob/0b5ce8712480dcf1ca88257f5159696a35351da7/geograypher/utils/parsing.py#L77)), representing a set of cameras that are mutually-registered to each other. With under-canopy data, it is common to have multiple components since registration is less robust. This PR uses the "active" component only, which I understand to correspond to the one which the mesh and other products are generated from. Any cameras not belonging to the active component are excluded from the camera set. 